### PR TITLE
Allow mutations only at integer sites

### DIFF
--- a/pyslim/__init__.py
+++ b/pyslim/__init__.py
@@ -3,3 +3,4 @@ from __future__ import division
 
 from pyslim.slim_metadata import *       # NOQA
 from pyslim.slim_tree_sequence import *  # NOQA
+from pyslim.mutate import *              # NOQA

--- a/pyslim/mutate.py
+++ b/pyslim/mutate.py
@@ -14,7 +14,7 @@ def infinite_alleles_factory(alleles):
 
 
 def mutate(ts, mutation_rate):
-    tables = ts.tables
+    tables = ts.dump_tables()
     edge_order = tables.nodes.time[tables.edges.child].argsort()
     site_pos = {}
     alleles = set(msprime.unpack_strings(tables.sites.ancestral_state,

--- a/pyslim/mutate.py
+++ b/pyslim/mutate.py
@@ -1,0 +1,53 @@
+import msprime
+import math
+import numpy as np
+
+from .slim_tree_sequence import *
+
+def infinite_alleles_factory(alleles):
+    next_allele = str(np.random.choice(1000000000000))
+    while True:
+        while next_allele in alleles:
+            next_allele = str(np.random.choice(1000000000000))
+        alleles.add(next_allele)
+        yield next_allele
+
+
+def mutate(ts, mutation_rate):
+    tables = ts.tables
+    edge_order = tables.nodes.time[tables.edges.child].argsort()
+    site_pos = {}
+    alleles = set(msprime.unpack_strings(tables.sites.ancestral_state,
+                                         tables.sites.ancestral_state_offset))
+    alleles.update(msprime.unpack_strings(tables.mutations.derived_state,
+                                          tables.mutations.derived_state_offset))
+    ag = infinite_alleles_factory(alleles)
+    for j, site in enumerate(ts.sites()):
+        site_pos[site.position] = j
+
+
+    for j in reversed(edge_order):
+        e = tables.edges[j]
+        left = math.ceil(e.left)
+        right = math.floor(e.right)
+        num_bp = 1 + right - left - (right == e.right)
+        if num_bp > 0:
+            edge_len = ts.node(e.parent).time - ts.node(e.child).time
+            mut_prob = 1 - math.exp(-1 * edge_len * mutation_rate)
+            num_muts = np.random.binomial(num_bp, mut_prob)
+            mut_bp = left + np.random.choice(num_bp, size=num_muts, replace=False)
+            for pos in mut_bp:
+                if pos not in site_pos:
+                    site = tables.sites.add_row(pos, ancestral_state='0')
+                    next_allele = 1
+                    site_pos[pos] = site
+                else:
+                    site = site_pos[pos]
+                
+                tables.mutations.add_row(site, e.child, derived_state=next(ag))
+
+    tables.sort()
+    tables.compute_mutation_parents()
+    delabel_alleles(tables)
+
+    return tables.tree_sequence()

--- a/pyslim/slim_tree_sequence.py
+++ b/pyslim/slim_tree_sequence.py
@@ -149,7 +149,7 @@ class SlimTreeSequence(msprime.TreeSequence):
         new_tables = ts.tables
         provenance = get_provenance(new_tables)
         _set_slim_generation(new_tables, provenance.slim_generation)
-        _delabel_alleles(new_tables)
+        delabel_alleles(new_tables)
         ts = msprime.TableCollection.tree_sequence(new_tables)
         return cls(ts, provenance.slim_generation)
 
@@ -228,7 +228,7 @@ def _make_allele_map(tables):
     return inv_alleles
 
 
-def _delabel_alleles(tables):
+def delabel_alleles(tables):
     '''
     Replaces alleles at each site by integers, starting with ``'0'`` for the
     ancestral state, placing the resulting list of dictionaries in the metadata

--- a/tests/test_annotation.py
+++ b/tests/test_annotation.py
@@ -28,8 +28,8 @@ class TestAnnotate(tests.PyslimTestCase):
         Verify that the tables returned after annotation are equal, up to the
         expected forgetting of metadata.
         '''
-        tables1 = ts1.tables
-        tables2 = ts2.tables
+        tables1 = ts1.dump_tables()
+        tables2 = ts2.dump_tables()
         # compare nodes
         self.assertArrayEqual(tables1.nodes.flags, tables2.nodes.flags)
         self.assertArrayAlmostEqual(tables1.nodes.time, tables2.nodes.time + time_offset)
@@ -67,13 +67,13 @@ class TestAnnotate(tests.PyslimTestCase):
         '''
         Verify the default values have been entered into metadata.
         '''
-        mut_md = pyslim.extract_mutation_metadata(ts.tables)
+        mut_md = pyslim.extract_mutation_metadata(ts.dump_tables())
         for md in mut_md:
             self.assertEqual(md.mutation_type, 1)
             self.assertEqual(md.selection_coeff, 0.0)
             self.assertEqual(md.population, msprime.NULL_POPULATION)
             self.assertEqual(md.slim_time, 0)
-        node_md = pyslim.extract_node_metadata(ts.tables)
+        node_md = pyslim.extract_node_metadata(ts.dump_tables())
         for md, node in zip(node_md, ts.nodes()):
             if not node.is_sample():
                 self.assertEqual(md, None)
@@ -83,11 +83,11 @@ class TestAnnotate(tests.PyslimTestCase):
         for ind in ts.individuals(): 
             self.assertArrayEqual(ind.location, [0, 0, 0])
             self.assertEqual(ind.flags, 0)
-        ind_md = pyslim.extract_individual_metadata(ts.tables)
+        ind_md = pyslim.extract_individual_metadata(ts.dump_tables())
         for md in ind_md:
             self.assertEqual(md.sex, pyslim.INDIVIDUAL_TYPE_HERMAPHRODITE)
             self.assertEqual(md.flags, 0)
-        pop_md = pyslim.extract_population_metadata(ts.tables)
+        pop_md = pyslim.extract_population_metadata(ts.dump_tables())
         for md in pop_md:
             self.assertEqual(md.selfing_fraction, 0.0)
             self.assertEqual(md.female_cloning_fraction, 0.0)
@@ -114,7 +114,7 @@ class TestAnnotate(tests.PyslimTestCase):
     def test_annotate_individuals(self):
         for ts in get_msprime_examples():
             slim_ts = pyslim.annotate_defaults(ts, model_type="nonWF", slim_generation=1)
-            tables = slim_ts.tables
+            tables = slim_ts.dump_tables()
             metadata = list(pyslim.extract_individual_metadata(tables))
             self.assertEqual(len(metadata), slim_ts.num_individuals)
             sexes = [random.choice([pyslim.INDIVIDUAL_TYPE_FEMALE, pyslim.INDIVIDUAL_TYPE_MALE])
@@ -130,7 +130,7 @@ class TestAnnotate(tests.PyslimTestCase):
     def test_annotate_mutations(self):
         for ts in get_msprime_examples():
             slim_ts = pyslim.annotate_defaults(ts, model_type="nonWF", slim_generation=1)
-            tables = slim_ts.tables
+            tables = slim_ts.dump_tables()
             metadata = list(pyslim.extract_mutation_metadata(tables))
             self.assertEqual(len(metadata), slim_ts.num_mutations)
             selcoefs = [random.uniform(0, 1) for _ in metadata]
@@ -145,7 +145,7 @@ class TestAnnotate(tests.PyslimTestCase):
     def test_annotate_nodes(self):
         for ts in get_msprime_examples():
             slim_ts = pyslim.annotate_defaults(ts, model_type="nonWF", slim_generation=1)
-            tables = slim_ts.tables
+            tables = slim_ts.dump_tables()
             metadata = list(pyslim.extract_node_metadata(tables))
             self.assertEqual(len(metadata), slim_ts.num_nodes)
             gtypes = [random.choice([pyslim.GENOME_TYPE_X, pyslim.GENOME_TYPE_Y])

--- a/tests/test_metadata.py
+++ b/tests/test_metadata.py
@@ -72,8 +72,8 @@ class TestAnnotate(unittest.TestCase):
 
     def test_annotate_mutations(self):
         for ts in get_slim_examples():
-            tables = ts.tables
-            new_tables = ts.tables
+            tables = ts.dump_tables()
+            new_tables = ts.dump_tables()
             metadata = []
             for md in msprime.unpack_bytes(tables.mutations.metadata, 
                                            tables.mutations.metadata_offset):
@@ -87,8 +87,8 @@ class TestAnnotate(unittest.TestCase):
 
     def test_annotate_nodes(self):
         for ts in get_slim_examples():
-            tables = ts.tables
-            new_tables = ts.tables
+            tables = ts.dump_tables()
+            new_tables = ts.dump_tables()
             metadata = []
             for md in msprime.unpack_bytes(tables.nodes.metadata, 
                                            tables.nodes.metadata_offset):
@@ -102,8 +102,8 @@ class TestAnnotate(unittest.TestCase):
 
     def test_annotate_individuals(self):
         for ts in get_slim_examples():
-            tables = ts.tables
-            new_tables = ts.tables
+            tables = ts.dump_tables()
+            new_tables = ts.dump_tables()
             metadata = []
             for md in msprime.unpack_bytes(tables.individuals.metadata, 
                                            tables.individuals.metadata_offset):
@@ -117,8 +117,8 @@ class TestAnnotate(unittest.TestCase):
 
     def test_annotate_populations(self):
         for ts in get_slim_examples():
-            tables = ts.tables
-            new_tables = ts.tables
+            tables = ts.dump_tables()
+            new_tables = ts.dump_tables()
             metadata = []
             for md in msprime.unpack_bytes(tables.populations.metadata, 
                                            tables.populations.metadata_offset):
@@ -145,10 +145,10 @@ class TestDumpLoad(tests.PyslimTestCase):
     def test_load_tables(self):
         for ts in get_slim_examples():
             self.assertTrue(type(ts) is pyslim.SlimTreeSequence)
-            tables = ts.tables
+            tables = ts.dump_tables()
             new_ts = pyslim.load_tables(tables, slim_format=True)
             self.assertTrue(type(new_ts) is pyslim.SlimTreeSequence)
-            new_tables = new_ts.tables
+            new_tables = new_ts.dump_tables()
             self.assertTablesAlmostEqual(tables, new_tables)
 
     def test_load(self):


### PR DESCRIPTION
I've written code that - I think - puts down mutations only at integer positions. With this branch, it worksl like this:
```
import msprime
import pyslim

ts = msprime.simulate(10, recombination_rate=0.01, length=100, mutation_rate=0.1)
new_ts = pyslim.mutate(ts, mutation_rate=0.2)

for h in new_ts.haplotypes():
    print(h)
```

It's simulating under an infinite alleles model, to avoid having to check if the parent mutation is the same.  We want this in `tskit` eventually, and implemented in C (this is pure python, so probably slow for big tree sequences) but we could provide this as a stopgap.