### PR TITLE
Remove allele remapping?

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,8 @@ history as a tree sequence, and in so doing it records extra information in meta
 This package makes it easy to add the relevant metadata to a tree sequence so that SLiM
 can use it, and to read the metadata in a SLiM-produced tree sequence.
 
+See the SLiM manual for more information.
+
 ## Installation
 
 To install `pyslim`, do

--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@ except ImportError:
 
 
 setup(name='pyslim',
-      version='0.0.5',
+      version='0.0.52',
       description=u"Manipulate tree sequences produced by SLiM.",
       long_description=long_description,
       classifiers=[],

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -46,11 +46,9 @@ class PyslimTestCase(unittest.TestCase):
         self.assertEqual(t1.provenances, t2.provenances)
 
     def verify_haplotype_equality(self, ts, slim_ts):
-        alleles = slim_ts.alleles
         self.assertEqual(ts.num_sites, slim_ts.num_sites)
-        self.assertEqual(ts.num_sites, len(alleles))
         for j, v1, v2 in zip(range(ts.num_sites), ts.variants(),
                              slim_ts.variants()):
             g1 = [v1.alleles[x] for x in v1.genotypes]
-            g2 = [alleles[j][v2.alleles[x]] for x in v2.genotypes]
+            g2 = [v2.alleles[x] for x in v2.genotypes]
             self.assertArrayEqual(g1, g2)


### PR DESCRIPTION
Perhaps switching ancestral and derived states to text may have made all that mucking around with alleles in pyslim obsolete, since msprime already does pretty much the same thing. `ts.genotype_matrix()` doesn't return a matrix of alleles, it returns a matrix of integers indexing into the corresponding `variant.alleles` - just like the allele remapping does - the only thing that doesn't work - I think - is `ts.haplotypes()`.  We had previously decided to remap alleles because binary states weren't compatible.