### PR TITLE
Remove allele mapping

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ __pycache__
 pyslim.egg-info/
 build/
 dist/
+pyslim/_version.py

--- a/README.md
+++ b/README.md
@@ -7,7 +7,8 @@ history as a tree sequence, and in so doing it records extra information in meta
 This package makes it easy to add the relevant metadata to a tree sequence so that SLiM
 can use it, and to read the metadata in a SLiM-produced tree sequence.
 
-See the SLiM manual for more information.
+The SLiM manual documents how the extra metadata is stored in the tree sequence files,
+and provides examples of how to use this package.
 
 ## Installation
 
@@ -41,22 +42,123 @@ import pyslim
 
 # simulate a tree sequence of 12 nodes
 ts = msprime.simulate(12, mutation_rate=1.0, recombination_rate=1.0)
-new_ts = pyslim.annotate_defaults(ts)
+new_ts = pyslim.annotate_defaults(ts, model_type="nonWF", slim_generation=1)
 new_ts.dump("slim_ts.trees")
 ```
 
 ## Quickstart: reading SLiM metadata
 
 To retrieve the extra information that SLiM stores in a tree sequence, use the `extract_X_metadata()`
-functions. For instance, to see the age of each Individual produced by annotation
+functions, where `X` is one of `mutation`, `population`, `node`, or `individual`.
+For instance, to see the age of each Individual produced by annotation
 in the previous example:
 ```
-for ind in extract_mutation_metadata(new_ts.tables):
+for ind in pyslim.extract_individual_metadata(new_ts.tables):
     print(ind.age)
 ```
+In this example, all the ages are 0 (the default).
+
+## Quickstart: modifying SLiM metadata
+
+To *modify* the metadata that `pyslim` has introduced into a coalescent simulation,
+or the metadata in a SLiM-produced tree sequence, use the `annotate_X_metadata()` functions.
+For instance, to set the ages of the individuals in the tree sequence to random numbers between 1 and 4,
+and write out the resulting tree sequence:
+```
+import random
+
+tables = new_ts.dump_tables()
+ind_md = list(pyslim.extract_individual_metadata(tables))
+for ind in ind_md:
+    ind.age = random.choice([1,2,3,4])
+
+pyslim.annotate_individual_metadata(tables, ind_md)
+mod_ts = pyslim.load_tables(tables, slim_format=True)
+
+for ind in pyslim.extract_individual_metadata(mod_ts.tables):
+    print(ind.age)
+
+mod_ts.dump("modified_ts.trees")
+```
+
+# Documentation
+
+Here we describe the technical details.
+
+## Metadata entries
+
+SLiM records additional information in the metadata columns of Population, Individual, Node, and Mutation tables.
+The information is recorded in a binary format, and is extracted and written by `pyslim` using the python `struct` module.
+This binary information can be the *only* thing in the metadata of these tables for the tree sequence to be used by SLiM,
+and so when `pyslim` annotates an existing tree sequence, anything in those columns is overwritten.
+For more detailed documentation on the contents and format of the metadata, see the SLiM manual.
+
+## Time and SLiM Tree Sequences
+
+The "time" in SLiM records the number of generations *since* the beginning of the simulation.
+However, since tree sequences naturally deal with history in retrospectively,
+properties related to "time" of tree sequences are measured in generations *ago*,
+i.e., generation *prior* to a given point.
+To distinguish these two notions of time, we'll talk about "SLiM time" and "tskit time".
+When SLiM records a tree sequence,
+it records tskit time in units of generations before the start of the simulation;
+so that all tskit times it records in the tree sequence are *negative*
+(because it measures how long *before* the start, but happened *after* the start).
+This is terribly counterintuitive. The fact that there are two notions of time 
+- one moving forwards, the other backwards -
+is unavoidable, but `pyslim` does one thing to make this easier to work with:
+when `pyslim` loads in a tree sequence file, it checks to see what the current SLiM time was
+at the end of the simulation, and shifts all times in the tree sequence so that tskit time
+is measured in generations before the *end* of the simulation.
+
+The upshot is that:
+
+1. The ``time`` attribute of tree sequence nodes gives the number of generations
+    before then end of the simulation at which those nodes were born.
+
+2. These numbers will *not* match the values in the `.trees` file, but you should not
+    need to worry about that, as long as you always `load()` and `dump()` using `pyslim`.
+
+3. The conversion factor, the "SLiM time" when the tree sequence file was written,
+    is stored in the `slim_generation` attribute of a `SlimTreeSequence`.
+
+An example should help clarify things.
+Suppose that `my.trees` is a file that was saved by SLiM at the end of a simulation run
+for 100 generations, and that
+we want to find the list of nodes in the tree sequence that were born during the first
+20 generations of the simulation.
+Since the birth time of a node is recorded in the `.time` attribute of a node
+in tskit time, a node that was born in the first 20 generations of the simulation,
+i.e., more than 80 generations before the end of the simulation,
+will have a `.time` attribute of at least 80.
+```
+ts = pyslim.load("my.trees", slim_format=True)
+old_nodes = []
+for n in ts.nodes():
+   if n.time > ts.slim_generation - 20:
+        old_nodes.append(n)
+```
+
+In the future, we may change this behavior,
+but if so will provide an upgrade path for old files.
+
+## SLiM Tree Sequences
+
+Because SLiM adds additional information to tree sequences,
+`pyslim` defines a subclass of `msprime.TreeSequence` to make it easy to access this information,
+and to make the time shift described above seamless.
+When you run `pyslim.load('my.trees', slim_format=True)`,
+you get a `SlimTreeSequence` object.
+This has all the same properties and methods as a plain `TreeSequence`,
+with the following differences:
+
+1. It has a `slim_generation` attribute.
+2. It's `.dump()` method shifts times by `slim_generation` before writing them out,
+    so that `pyslim.load("my.trees", slim_format=True).dump("my2.trees")`
+    writes out a tree sequence identical to the one that was read in (up to floating point error).
 
 
-## Important notes:
+## Other important notes:
 
 1. `tskit` "nodes" correspond to SLiM "genomes".  Individuals are diploid, so each individual has two nodes.
 

--- a/README.md
+++ b/README.md
@@ -7,6 +7,8 @@ history as a tree sequence, and in so doing it records extra information in meta
 This package makes it easy to add the relevant metadata to a tree sequence so that SLiM
 can use it, and to read the metadata in a SLiM-produced tree sequence.
 
+See the SLiM manual for more information.
+
 ## Installation
 
 To install `pyslim`, do

--- a/pyslim/__init__.py
+++ b/pyslim/__init__.py
@@ -3,3 +3,4 @@ from __future__ import division
 
 from pyslim.slim_metadata import *       # NOQA
 from pyslim.slim_tree_sequence import *  # NOQA
+from pyslim.provenance import *          # NOQA

--- a/pyslim/provenance.py
+++ b/pyslim/provenance.py
@@ -1,0 +1,18 @@
+__version__ = "undefined"
+try:
+    from . import _version
+    __version__ = _version.version
+except ImportError:
+    pass
+
+def get_provenance_dict():
+    """
+    Returns a dictionary encoding the version of pyslim used.
+    """
+    document = {
+        "software": "pyslim",
+        "version": __version__
+    }
+    return document
+
+

--- a/pyslim/slim_tree_sequence.py
+++ b/pyslim/slim_tree_sequence.py
@@ -5,10 +5,10 @@ import json
 from collections import OrderedDict
 
 from .slim_metadata import *
+from .provenance import *
 
 SLIM_VERSION = "3.0"
 SLIM_FILE_VERSION = "0.1"
-PYSLIM_VERSION = "0.1"
 
 def load(path, slim_format):
     '''
@@ -460,8 +460,9 @@ def _set_provenance(tables, model_type, slim_generation, remembered_node_count=0
     :param int slim_generation: The "current" generation in the SLiM simulation.
     :param int remembered_node_count: The number of nodes that will be "remembered".
     '''
+    pyslim_provenance = get_provenance_dict()
     pyslim_dict = OrderedDict([("program", "pyslim"),
-                               ("version", PYSLIM_VERSION)])
+                               ("version", pyslim_provenance['version'])])
     slim_dict = OrderedDict([
                  ("program", "SLiM"), ("version", SLIM_VERSION),
                  ("file_version", SLIM_FILE_VERSION),

--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@ except ImportError:
 
 
 setup(name='pyslim',
-      version='0.0.52',
+      version='0.0.53',
       description=u"Manipulate tree sequences produced by SLiM.",
       long_description=long_description,
       classifiers=[],
@@ -31,4 +31,6 @@ setup(name='pyslim',
       extras_require={
           'dev': [],
       },
+      setup_requires=['setuptools_scm'],
+      use_scm_version={"write_to": "pyslim/_version.py"}
       )

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -46,11 +46,9 @@ class PyslimTestCase(unittest.TestCase):
         self.assertEqual(t1.provenances, t2.provenances)
 
     def verify_haplotype_equality(self, ts, slim_ts):
-        alleles = slim_ts.alleles
         self.assertEqual(ts.num_sites, slim_ts.num_sites)
-        self.assertEqual(ts.num_sites, len(alleles))
         for j, v1, v2 in zip(range(ts.num_sites), ts.variants(),
                              slim_ts.variants()):
             g1 = [v1.alleles[x] for x in v1.genotypes]
-            g2 = [alleles[j][v2.alleles[x]] for x in v2.genotypes]
+            g2 = [v2.alleles[x] for x in v2.genotypes]
             self.assertArrayEqual(g1, g2)

--- a/tests/test_annotation.py
+++ b/tests/test_annotation.py
@@ -23,7 +23,7 @@ class TestAnnotate(tests.PyslimTestCase):
     Tests for tools to annotate existing msprime-derived tree sequences.
     '''
 
-    def verify_annotated_tables(self, ts1, ts2, time_offset):
+    def verify_annotated_tables(self, ts1, ts2):
         '''
         Verify that the tables returned after annotation are equal, up to the
         expected forgetting of metadata.
@@ -32,7 +32,7 @@ class TestAnnotate(tests.PyslimTestCase):
         tables2 = ts2.tables
         # compare nodes
         self.assertArrayEqual(tables1.nodes.flags, tables2.nodes.flags)
-        self.assertArrayAlmostEqual(tables1.nodes.time, tables2.nodes.time + time_offset)
+        self.assertArrayAlmostEqual(tables1.nodes.time, tables2.nodes.time)
         self.assertArrayEqual(tables1.nodes.population, tables2.nodes.population)
         # compare edges
         self.assertEqual(tables1.edges, tables2.edges)
@@ -106,7 +106,7 @@ class TestAnnotate(tests.PyslimTestCase):
             slim_gen = 4
             slim_ts = pyslim.annotate_defaults(ts, model_type="WF",
                                                slim_generation=slim_gen)
-            self.verify_annotated_tables(ts, slim_ts, time_offset=slim_gen)
+            self.verify_annotated_tables(ts, slim_ts)
             self.verify_annotated_trees(ts, slim_ts)
             self.verify_haplotype_equality(ts, slim_ts)
             self.verify_defaults(slim_ts)


### PR DESCRIPTION
Perhaps switching ancestral and derived states to text may have made all that mucking around with alleles in pyslim obsolete, since msprime already does pretty much the same thing. ts.genotype_matrix() doesn't return a matrix of alleles, it returns a matrix of integers indexing into the corresponding variant.alleles - just like the allele remapping does - the only thing that doesn't work - I think - is ts.haplotypes(). We had previously decided to remap alleles because binary states weren't compatible.