### PR TITLE
Population annotations are now made correctly.

### DIFF
--- a/pyslim/slim_tree_sequence.py
+++ b/pyslim/slim_tree_sequence.py
@@ -299,8 +299,8 @@ def _set_nodes_individuals(
     if ind_population is None:
         # set the individual populations based on what's in the nodes
         ind_population = [msprime.NULL_POPULATION for _ in range(num_individuals)]
-        for j, u in enumerate(node_ind):
-            ind_population[u] = tables.nodes.population[j]
+        for j, u in enumerate(range(num_individuals)):
+            ind_population[u] = tables.nodes.population[2*j]
     assert(len(ind_population) == num_individuals)
 
     # check for consistency: every individual has two nodes, and populations agree


### PR DESCRIPTION
Hello,

I noticed that the annotate_defaults() function returns an error when the node tables have non-trivial population info in them.

I'm not super familiar with setting up tests in Python, but I have written a short standalone script (found [here](https://github.com/gtsambos/AdmixtureSim/commit/fecbc66641142bfadc84ec63f44335dccba334d6)) that illustrates the problem.

I think this can be fixed with my commit - feel free to pull it into your repo if you find it useful.

Cheers,
Georgia (PhD student at the University of Melbourne, Australia)