### PR TITLE
Add decoded metadata to objects (and individual time, population)

### DIFF
--- a/pyslim/slim_tree_sequence.py
+++ b/pyslim/slim_tree_sequence.py
@@ -210,6 +210,29 @@ class SlimTreeSequence(tskit.TreeSequence):
 
         return ret
 
+    def population(self, id_):
+        '''
+        Returns the population whose ID is given by `id_`, as documented in
+        `msprime.population`, but with additional attributes:
+            slim_id, selfing_fraction, female_cloning_fraction, 
+            male_cloning_fraction, sex_ratio, 
+            bounds_x0, bounds_x1, bounds_y0, bounds_y1, bounds_z0, bounds_z1, 
+            and migration_records.
+        These are all recorded by SLiM in the metadata.
+
+        Note that SLiM populations are usually indexed starting from 1,
+        but in tskit from zero, so there may be populations (e.g., with id_=0)
+        that have no metadata and are not used by SLiM.
+
+        :param int id_: The ID of the population (i.e., its index).
+        '''
+        pop = super(SlimTreeSequence, self).population(id_)
+        try:
+            pop.metadata = decode_population(pop.metadata)
+        except:
+            pass
+        return pop
+
     def individual(self, id_):
         '''
         Returns the individual whose ID is given by `id_`, as documented in
@@ -224,8 +247,27 @@ class SlimTreeSequence(tskit.TreeSequence):
         ind = super(SlimTreeSequence, self).individual(id_)
         ind.population = self.individual_populations[id_]
         ind.time = self.individual_times[id_]
-        ind.metadata = decode_individual(ind.metadata)
+        try:
+            ind.metadata = decode_individual(ind.metadata)
+        except:
+            pass
         return ind
+
+    def node(self, id_):
+        '''
+        Returns the node whose ID is given by `id_`, as documented in
+        `msprime.node`, but with additional attributes:
+           slim_id, is_null, genome_type.
+        These are all recorded by SLiM in the metadata.
+
+        :param int id_: The ID of the node (i.e., its index).
+        '''
+        node = super(SlimTreeSequence, self).node(id_)
+        try:
+            node.metadata = decode_node(node.metadata)
+        except:
+            pass
+        return node
 
     def mutation(self, id_):
         '''
@@ -237,7 +279,10 @@ class SlimTreeSequence(tskit.TreeSequence):
         :param int id_: The ID of the mutation (i.e., its index).
         '''
         mut = super(SlimTreeSequence, self).mutation(id_)
-        mut.metadata = decode_mutation(mut.metadata)
+        try:
+            mut.metadata = decode_mutation(mut.metadata)
+        except:
+            pass
         return mut
 
     def recapitate(self, recombination_rate, keep_first_generation=False,

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -11,8 +11,12 @@ import unittest
 import base64
 import os
 
+# recipes that record everyone ever
+_everyone_example_files = ["tests/examples/recipe_record_everyone"]
+
 _example_files = ["tests/examples/recipe_{}".format(x)
-                  for x in ['WF', 'nonWF', 'nucleotides']]
+                  for x in ['WF', 'nonWF', 'nucleotides']] + \
+                 _everyone_example_files
 
 # this is of the form (input, basename)
 # TODO: test restarting of nucleotides after reference sequence dumping is enabled
@@ -81,6 +85,13 @@ class PyslimTestCase(unittest.TestCase):
 
     def get_slim_examples(self):
         for treefile in self.get_slim_example_files():
+            print("---->", treefile)
+            self.assertTrue(os.path.isfile(treefile))
+            yield pyslim.load(treefile)
+
+    def get_slim_everyone_examples(self):
+        for filename in _everyone_example_files:
+            treefile = filename + ".trees"
             print("---->", treefile)
             self.assertTrue(os.path.isfile(treefile))
             yield pyslim.load(treefile)

--- a/tests/examples/recipe_record_everyone.slim
+++ b/tests/examples/recipe_record_everyone.slim
@@ -1,0 +1,37 @@
+initialize()
+{
+    setSeed(23);
+    initializeSLiMModelType("nonWF");
+    initializeSLiMOptions(dimensionality="xy");
+    initializeTreeSeq();
+    initializeMutationRate(1e-2);
+    initializeMutationType("m1", 0.5, "f", -0.1);
+    initializeGenomicElementType("g1", m1, 1.0);
+    initializeGenomicElement(g1, 0, 99);
+    initializeRecombinationRate(1e-2);
+    defineConstant("K", 10);
+}
+
+reproduction() {
+    subpop.addCrossed(individual, subpop.sampleIndividuals(1));
+}
+
+1 early() {
+    sim.addSubpop("p1", 10);
+    for (ind in p1.individuals)
+        ind.setSpatialPosition(p1.pointUniform());
+}
+
+early() {
+    p1.fitnessScaling = K / p1.individualCount;
+}
+
+early() {
+    sim.treeSeqRememberIndividuals(p1.individuals);
+}
+
+10 {
+    sim.treeSeqOutput("recipe_record_everyone.trees");
+    catn("Done.");
+    sim.simulationFinished();
+}

--- a/tests/test_annotation.py
+++ b/tests/test_annotation.py
@@ -166,7 +166,7 @@ class TestAnnotate(tests.PyslimTestCase):
             pyslim.annotate_individual_metadata(tables, metadata)
             new_ts = pyslim.load_tables(tables)
             for j, ind in enumerate(new_ts.individuals()):
-                md = pyslim.decode_individual(ind.metadata)
+                md = ind.metadata
                 self.assertEqual(md.sex, sexes[j])
             # try loading this into SLiM
             loaded_ts = self.run_msprime_restart(new_ts, sex="A")
@@ -237,7 +237,7 @@ class TestAnnotate(tests.PyslimTestCase):
             pyslim.annotate_mutation_metadata(tables, metadata)
             new_ts = pyslim.load_tables(tables)
             for j, x in enumerate(new_ts.mutations()):
-                md = pyslim.decode_mutation(x.metadata)
+                md = x.metadata
                 self.assertEqual(md.selection_coeff, selcoefs[j])
 
     def test_reload_recapitate(self):

--- a/tests/test_annotation.py
+++ b/tests/test_annotation.py
@@ -220,7 +220,7 @@ class TestAnnotate(tests.PyslimTestCase):
             pyslim.annotate_node_metadata(tables, metadata)
             new_ts = pyslim.load_tables(tables)
             for j, x in enumerate(new_ts.nodes()):
-                md = pyslim.decode_node(x.metadata)
+                md = x.metadata
                 if md is not None:
                     self.assertEqual(md.genome_type, gtypes[j])
             # not testing SLiM because needs annotation of indivs to make sense

--- a/tests/test_metadata.py
+++ b/tests/test_metadata.py
@@ -219,7 +219,7 @@ class TestNucleotides(tests.PyslimTestCase):
         -1, 0, 1, 2, or 3.
         '''
         for mut in ts.mutations():
-            for u in pyslim.decode_mutation(mut.metadata):
+            for u in mut.metadata:
                 self.assertGreaterEqual(u.nucleotide, -1)
                 self.assertLessEqual(u.nucleotide, 3)
 

--- a/tests/test_metadata.py
+++ b/tests/test_metadata.py
@@ -18,6 +18,56 @@ class TestEncodeDecode(tests.PyslimTestCase):
     Tests for conversion to/from binary representations of metadata.
     '''
 
+    def test_decode_errors(self):
+        with self.assertRaises(ValueError):
+            pyslim.decode_mutation(2.0)
+        with self.assertRaises(ValueError):
+            pyslim.decode_mutation([2.0, 3.0])
+        with self.assertRaises(ValueError):
+            pyslim.decode_node(2.0)
+        with self.assertRaises(ValueError):
+            pyslim.decode_node([1, 2])
+        with self.assertRaises(ValueError):
+            pyslim.decode_individual(3.0)
+        with self.assertRaises(ValueError):
+            pyslim.decode_individual([1, 2])
+        with self.assertRaises(ValueError):
+            pyslim.decode_population(1.0)
+        with self.assertRaises(ValueError):
+            pyslim.decode_population([2, 3])
+
+    def test_decode_already_mutation(self):
+        m = [pyslim.MutationMetadata(mutation_type = 0,
+                                     selection_coeff = 0.2,
+                                     population = k,
+                                     slim_time = 130,
+                                     nucleotide = 2) for k in range(4)]
+        dm = pyslim.decode_mutation(m)
+        self.assertEqual(type(dm), type([]))
+        for a, b in zip(m, dm):
+            self.assertEqual(a, b)
+
+    def test_decode_already_node(self):
+        m = pyslim.NodeMetadata(slim_id=123, is_null=True, genome_type=0)
+        dm = pyslim.decode_node(m)
+        self.assertEqual(m, dm)
+
+    def test_decode_already_population(self):
+        m = pyslim.PopulationMetadata(slim_id=1, selfing_fraction=0.2,
+                                      female_cloning_fraction=0.3,
+                                      male_cloning_fraction=0.4,
+                                      sex_ratio=0.5, bounds_x0=0, bounds_x1=10,
+                                      bounds_y0=2, bounds_y1=20, bounds_z0=3,
+                                      bounds_z1=30, migration_records=[])
+        dm = pyslim.decode_population(m)
+        self.assertEqual(m, dm)
+
+    def test_decode_already_individual(self):
+        m = pyslim.IndividualMetadata(pedigree_id=24, age=8, population=1,
+                                      sex=1, flags=0)
+        dm = pyslim.decode_individual(m)
+        self.assertEqual(m, dm)
+
     def test_mutation_metadata(self):
         for md_length in [0, 1, 5]:
             md = [pyslim.MutationMetadata(

--- a/tests/test_tree_sequence.py
+++ b/tests/test_tree_sequence.py
@@ -73,6 +73,29 @@ class TestRecapitation(tests.PyslimTestCase):
                                            delta = 1e-4)
 
 
+class TestIndividualMetadata(tests.PyslimTestCase):
+    '''
+    Tests for extra stuff in Individuals.
+    '''
+
+    def test_node_derived_info(self):
+        for ts in self.get_slim_examples():
+            for ind in ts.individuals():
+                for n in ind.nodes:
+                    self.assertEqual(ts.node(n).population, ind.population)
+                    self.assertEqual(ts.node(n).time, ind.time)
+
+    def test_metadata(self):
+        for ts in self.get_slim_examples():
+            for ind in ts.individuals():
+                md = pyslim.decode_individual(ind.metadata)
+                self.assertEqual(md.pedigree_id, ind.pedigree_id)
+                self.assertEqual(md.age, ind.age)
+                self.assertEqual(md.population, ind.slim_population)
+                self.assertEqual(md.sex, ind.sex)
+                self.assertEqual(md.flags, ind.slim_flags)
+
+
 class TestSimplify(tests.PyslimTestCase):
     '''
     Our simplify() is just a wrapper around the tskit simplify.

--- a/tests/test_tree_sequence.py
+++ b/tests/test_tree_sequence.py
@@ -52,7 +52,6 @@ class TestRecapitation(tests.PyslimTestCase):
             assert ts.num_populations == 2
             # if not we need migration rates
             for keep_first in [True, False]:
-                print("keep?", keep_first)
                 recap = ts.recapitate(recombination_rate = 1.0,
                                       keep_first_generation=keep_first)
                 # there should be no new mutations
@@ -87,6 +86,7 @@ class TestIndividualMetadata(tests.PyslimTestCase):
                 raw_md = ts.tables.individuals.metadata[a:b]
                 md = pyslim.decode_individual(raw_md)
                 self.assertEqual(ind.metadata, md)
+                self.assertEqual(ts.individual(j).metadata, md)
                 for n in ind.nodes:
                     self.assertEqual(ts.node(n).population, ind.population)
                     self.assertEqual(ts.node(n).time, ind.time)
@@ -103,6 +103,22 @@ class TestIndividualMetadata(tests.PyslimTestCase):
                 self.assertArrayEqual(ts.individual_locations[j], ind.location)
 
 
+class TestNodeMetadata(tests.PyslimTestCase):
+    '''
+    Tests for extra stuff related to Nodes.
+    '''
+
+    def test_node_derived_info(self):
+        for ts in self.get_slim_examples():
+            for j, node in enumerate(ts.nodes()):
+                a = ts.tables.nodes.metadata_offset[j]
+                b = ts.tables.nodes.metadata_offset[j+1]
+                raw_md = ts.tables.nodes.metadata[a:b]
+                md = pyslim.decode_node(raw_md)
+                self.assertEqual(node.metadata, md)
+                self.assertEqual(ts.node(j).metadata, md)
+
+
 class TestMutationMetadata(tests.PyslimTestCase):
     '''
     Tests for extra stuff related to Mutations.
@@ -116,6 +132,23 @@ class TestMutationMetadata(tests.PyslimTestCase):
                 raw_md = ts.tables.mutations.metadata[a:b]
                 md = pyslim.decode_mutation(raw_md)
                 self.assertEqual(mut.metadata, md)
+                self.assertEqual(ts.mutation(j).metadata, md)
+
+
+class TestPopulationMetadata(tests.PyslimTestCase):
+    '''
+    Tests for extra stuff related to Populations.
+    '''
+
+    def test_population_derived_info(self):
+        for ts in self.get_slim_examples():
+            for j, pop in enumerate(ts.populations()):
+                a = ts.tables.populations.metadata_offset[j]
+                b = ts.tables.populations.metadata_offset[j+1]
+                raw_md = ts.tables.populations.metadata[a:b]
+                md = pyslim.decode_population(raw_md)
+                self.assertEqual(pop.metadata, md)
+                self.assertEqual(ts.population(j).metadata, md)
 
 
 class TestEveryone(tests.PyslimTestCase):


### PR DESCRIPTION
Individuals carry a list of nodes, and nodes have `time` and `population` for historical reasons. Here I've propagated these properties to the `individual`, and throw an error if they don't all agree.  Anything else along these lines we should propagate?  Are there any use cases where we expect more than one time or population?