### PR TITLE
added simplify

### DIFF
--- a/pyslim/slim_tree_sequence.py
+++ b/pyslim/slim_tree_sequence.py
@@ -140,6 +140,28 @@ class SlimTreeSequence(tskit.TreeSequence):
         ts = tables.tree_sequence()
         return cls(ts)
 
+    def simplify(self, *args, **kwargs):
+        '''
+        This is a wrapper for msprime.TreeSequence.Simplify().
+        The only difference is that this method returns the
+        derived class SlimTreeSequence.
+
+        Documentation for this function and its arguments
+        can be found at:
+        https://github.com/tskit-dev/tskit/blob/master/python/tskit/trees.py
+
+        :param *args: list of arguments to feed msprime.TreeSequence.Simplify()
+        :param **kwargs: keyword specific aguments stored in a dictionary.
+        :rtype SlimTreeSequence:
+        '''
+        sts = super(SlimTreeSequence,self).simplify(*args, **kwargs)
+        if (type(sts) == tuple):
+            ret = (SlimTreeSequence(sts[0]), sts[1])
+        else:
+            ret = SlimTreeSequence(sts)
+
+        return ret
+
     def recapitate(self, recombination_rate, keep_first_generation=False,
                    population_configurations=None, **kwargs):
         '''

--- a/tests/test_tree_sequence.py
+++ b/tests/test_tree_sequence.py
@@ -71,3 +71,16 @@ class TestRecapitation(tests.PyslimTestCase):
                     self.assertAlmostEqual(recap.node(t.root).time, 
                                            recap.slim_generation, 
                                            delta = 1e-4)
+
+
+class testSimplify(tests.PyslimTestCase):
+    '''
+    Our simplify() is just a wrapper around the tskit simplify.
+    '''
+
+    def test_simplify(self):
+        for ts in self.get_slim_examples():
+            sts = ts.simplify()
+            self.assertEqual(ts.sequence_length, sts.sequence_length)
+            self.assertEqual(type(ts), type(sts))
+            self.assertEqual(sts.samples()[0], 0)    


### PR DESCRIPTION
So I added the simplify() method that should override the superclass method and return `<class 'pyslim.slim_tree_sequence.SlimTreeSequence'>` after simplifying the tables directly. I'm still confused about the provenance tables; So `The record_provenance` parameter is deprecated until somebody can fix that portion real quick. :) 