### PR TITLE
Use metadata schemas

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -5,9 +5,11 @@
 **Notable changes**:
 
 - Switched to using tskit native encoding/decoding of metadata via schemas.
+- added to conda-forge (@winni2k)
 
 **New features**:
 
+- enabled dumping the reference sequence for nucleotide models
 - added has_individual_parents, a method to find individuals with all parents
   are also recorded as individuals
 - Provenance handling:

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,6 +2,10 @@
 [UPCOMING.X.X] - XXXX-XX-XX
 ***************************
 
+**Notable changes**:
+
+- Switched to using tskit native encoding/decoding of metadata via schemas.
+
 **New features**:
 
 - added has_individual_parents, a method to find individuals with all parents

--- a/pyslim/_version.py
+++ b/pyslim/_version.py
@@ -1,2 +1,3 @@
 # coding: utf-8
 pyslim_version = '0.401'
+slim_file_version = '0.4'

--- a/pyslim/slim_tree_sequence.py
+++ b/pyslim/slim_tree_sequence.py
@@ -178,6 +178,23 @@ class SlimTreeSequence(tskit.TreeSequence):
         ts = tables.tree_sequence()
         return cls(ts, **kwargs)
 
+    def dump(self, path, **kwargs):
+        '''
+        Dumps the tree sequence to the path specified. This is mostly just a wrapper for
+        tskit.TreeSequence.dump(), but also writes out the reference sequence.
+
+        :param str path: The file path to write the TreeSequence to.
+        :param dict **kwargs: Additional keyword args to pass to tskit.TreeSequence.dump
+        '''
+        super().dump(path, **kwargs)
+        if self.reference_sequence is not None:
+            # to convert to a kastore store we need to reload from a file,
+            # and for it to be mutable we need to make it a dict
+            kas = dict(kastore.load(path))
+            kas['reference_sequence/data'] = np.frombuffer(self.reference_sequence.encode(),
+                                                           dtype=np.uint32)
+            kastore.dump(kas, path)
+
     def simplify(self, *args, **kwargs):
         '''
         This is a wrapper for :meth:`tskit.TreeSequence.simplify`.

--- a/pyslim/slim_tree_sequence.py
+++ b/pyslim/slim_tree_sequence.py
@@ -184,7 +184,7 @@ class SlimTreeSequence(tskit.TreeSequence):
         tskit.TreeSequence.dump(), but also writes out the reference sequence.
 
         :param str path: The file path to write the TreeSequence to.
-        :param dict **kwargs: Additional keyword args to pass to tskit.TreeSequence.dump
+        :param **kwargs: Additional keyword args to pass to tskit.TreeSequence.dump
         '''
         super().dump(path, **kwargs)
         if self.reference_sequence is not None:

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -41,7 +41,8 @@ for f in example_files:
     example_files[f]['basename'] = os.path.join("tests", "examples", f)
 
 
-# this is of the form (input, basename)
+# These SLiM scripts read in an existing trees file; the format in this list
+# is of the form: (<input trees file>, <basename of slim script and output file>)
 # TODO: test restarting of nucleotides after reference sequence dumping is enabled
 _restart_files = [("tests/examples/recipe_{}.trees".format(x),
                    "tests/examples/restart_{}".format(x))
@@ -135,12 +136,16 @@ class PyslimTestCase(unittest.TestCase):
                     yield ts
 
     def get_slim_restarts(self):
+        # Loads previously produced tree sequences and SLiM scripts 
+        # appropriate for restarting from these tree sequences.
         for treefile, basename in _restart_files:
             self.assertTrue(os.path.isfile(treefile))
             ts = pyslim.load(treefile)
             yield ts, basename
 
     def run_slim_restart(self, in_ts, basename, args=''):
+        # Saves out the tree sequence to the trees file that the SLiM script
+        # basename.slim will load from.
         infile = basename + ".init.trees"
         outfile = basename + ".trees"
         slimfile = basename + ".slim"
@@ -151,12 +156,11 @@ class PyslimTestCase(unittest.TestCase):
                 pass
         in_ts.dump(infile)
         out = run_slim_script(slimfile, args=args)
-        print("out:", out)
         try:
             os.remove(infile)
         except FileNotFoundError:
             pass
-        assert out == 0
+        self.assertEqual(out, 0)
         self.assertTrue(os.path.isfile(outfile))
         out_ts = pyslim.load(outfile)
         try:

--- a/tests/test_annotation.py
+++ b/tests/test_annotation.py
@@ -216,9 +216,7 @@ class TestAnnotate(tests.PyslimTestCase):
                 self.assertEqual(md.selection_coeff, selcoefs[j])
 
     def test_reload_recapitate(self):
-        """
-        Test the ability of SLiM to load our files after recapitation.
-        """
+        # Test the ability of SLiM to load our files after recapitation.
         for ts, basename in self.get_slim_restarts():
             # recapitate, reload
             in_ts = ts.recapitate(recombination_rate=1e-2, Ne=10)
@@ -228,9 +226,7 @@ class TestAnnotate(tests.PyslimTestCase):
             self.verify_slim_restart_equality(in_ts, out_ts)
 
     def test_reload_annotate(self):
-        """
-        Test the ability of SLiM to load our files after annotation.
-        """
+        # Test the ability of SLiM to load our files after annotation.
         for ts, basename in self.get_slim_restarts():
             tables = ts.tables
             metadata = list(pyslim.extract_mutation_metadata(tables))

--- a/tests/test_metadata.py
+++ b/tests/test_metadata.py
@@ -231,6 +231,7 @@ class TestDumpLoad(tests.PyslimTestCase):
         self.assertEqual(ts.num_samples, ts2.num_samples)
         self.assertEqual(ts.sequence_length, ts2.sequence_length)
         self.assertEqual(ts.tables, ts2.tables)
+        self.assertEqual(ts.reference_sequence, ts2.reference_sequence)
 
     def assert_equality_except_schemas(self, tables1, tables2):
         t1 = tables1.copy()


### PR DESCRIPTION
The interface for metadata is unchanged, but under the hood uses the new metadata schemas in tskit. We shouldn't merge this until SLiM writes out metadata schemas to the tables: mostly, everything is the same, except that previously, we allowed non-SLiM metadata (eg empty metadata), but that will no longer be allowed; this may break previous code that relied on checking the presence of metadata to see if mutations or nodes were added by SLiM or if populations were used.

Furthermore, `msprime.mutate( )` will no longer return a trivially SlimTreeSequence-able tree sequence, because newly added mutations will need SLiM metadata. I suppose this calls for a `pyslim.mutate( )` method, and previous code, which did `pyslim.SlimTreeSequence(msprime.mutate(...))` will break - unless we have `pyslim.SlimTreeSequence( )` add default metadata to entries in need of such.  We'll probably want to write a `pyslim.mutate( )` method using the slim mutation generation ability of msprime, anyhow.

Note that the code in this PR already adds default metadata for populations without metadata.

Similarly, `pyslim.recapitate( )` will need to be modified to add metadata to newly added nodes.

It would also be very nice to ditch the metadata processing we do here enitrely - leave the metadata as dicts as returned by tskit instead of translating them to objects. That would be a more serious change, although if we're making breaking changes, then perhaps it's OK - it would only require changing code from e.g. `node.metadata.slim_id` to `node.metadata['slim_id']`.