### PR TITLE
Deprecate old metadata handling

### DIFF
--- a/docs/development.rst
+++ b/docs/development.rst
@@ -5,7 +5,7 @@ Development
 ===========
 
 
-To install a particular version of `pyslim` from source, e.g., to obtain a recent update::
+To install a particular version of ``pyslim`` from source, e.g., to obtain a recent update::
 
 
    $ git clone https://github.com/tskit-dev/pyslim.git
@@ -18,9 +18,9 @@ Then, to run the tests to make sure everything is working, do::
 
    $ python -m nose tests -vs
 
-*Note:* if you use `python3` you may need to replace `python` with `python3` above.
+*Note:* if you use ``python3`` you may need to replace ``python`` with ``python3`` above.
 
-If you would like to add some features to ``pyslim``, please read the
+If you would like to add some features to ```pyslim```, please read the
 following. If you think there is anything missing,
 please open an `issue <http://github.com/tskit-dev/pyslim/issues>`_ or
 `pull request <http://github.com/tskit-dev/pyslim/pulls>`_ on GitHub!

--- a/docs/introduction.rst
+++ b/docs/introduction.rst
@@ -17,8 +17,7 @@ SLiM can read and write *tree sequences*, which store genealogical data of entir
 These can be used to efficiently store both the state of the population at various points
 during a simulation *as well as* its genealogical history. Furthermore, SLiM can "load" a saved tree sequence
 file to recreate the exact state of the population at the time it was saved.
-To do this, SLiM has added several additional types of information to the basic tree sequence file
-(in "metadata"); this package makes it easy to read and write this information.
+To do this, SLiM has added several additional types of information to the basic tree sequence file.
 
 ********
 Overview

--- a/docs/metadata.rst
+++ b/docs/metadata.rst
@@ -101,3 +101,18 @@ SLiM will not use the metadata of nodes that are not associated with alive indiv
 so this can safely be omitted (and makes recapitation easier).
 And, populations not used by SLiM will have empty metadata.
 All remaining metadata are required (besides edges and sites, whose metadata is not used at all).
+
+
+.. _sec_legacy_metadata:
+
+===============
+Legacy metadata
+===============
+
+TODO: fill this in
+
+Need to change
+
+- `node.metadata.X` to `node.metadata["X"]`
+- `mutation.metadata[k].X` to `mutation.metadata["mutation_list"][k]["X"]`
+- `individual.metadata.population` to `individual.metadata["subpopulation"]` (note the *sub*)

--- a/docs/metadata.rst
+++ b/docs/metadata.rst
@@ -19,8 +19,8 @@ and times in the tree sequence record how long before the end of the simulation.
 However, off-by-one errors are easy to make, so we'll spell it out in detail.
 
 When the tree sequence is written out, SLiM records the value of its current generation,
-which can be found in the metadata: `ts.metadata['SLiM']['generation']`
-(or, the `ts.slim_generation` attribute).
+which can be found in the metadata: ``ts.metadata['SLiM']['generation']``
+(or, the ``ts.slim_generation`` attribute).
 In most cases, the "SLiM time" referred to by a ``time`` in the tree sequence
 (i.e., the value that would be reported by ``sim.generation``
 within SLiM at the point in time thus referenced)
@@ -30,7 +30,7 @@ so if the tree sequence was written out using ``sim.treeSeqOutput()`` during "ea
 the tree sequence's times measure time before the last set of individuals are born,
 i.e., before SLiM time step ``ts.slim_generation - 1``.
 The stage that the tree sequence was saved is recorded in the metadata of the tree sequence,
-as `ts.metadata['SLiM']['stage']`.
+as ``ts.metadata['SLiM']['stage']``.
 Using this, we can convert from the times of a tree sequence ``ts``
 to SLiM time as follows:
 
@@ -51,13 +51,45 @@ during "late()" as well, unless you have good reason not to.
 (This means you *must specify* the stage of the block in your SLiM script,
 since the stage defaults to "early()"!)
 
-
 ***********************
 Modifying SLiM metadata
 ***********************
 
-To *modify* the metadata that ``pyslim`` has introduced into a coalescent simulation,
-or the metadata in a SLiM-produced tree sequence, use the ``annotate_X_metadata()`` functions.
+For more on working with metadata,
+see `tskit's metadata documentation <https://tskit.readthedocs.io/en/latest/metadata.html#sec-metadata>`_.
+
+++++++++++++++++++
+Top-level metadata
+++++++++++++++++++
+
+The entries of the top-level metadata dict are *read-only*: so,
+you might think that
+``tables.metadata["SLiM"]["model_type"] = "nonWF"`` would switch the model type,
+but this in fact (silently) does nothing. To modify the top-level metadata,
+we must (a) work with tables (as tree sequences are immutable, and (b)
+extract the metadata dict, modify the dict, and copy it back in.
+Instead, you should do
+
+.. code-block:: python
+
+   md = tables.metadata
+   md["SLiM"]["model_type"] = "nonWF"
+   tables.metadata = md
+
+Modifying the top-level metadata
+could be used to set spatial bounds on an annotated msprime simulation, for instance.
+
+
++++++++++++++++++++++++++++++++++
+Modifying SLiM metadata in tables
++++++++++++++++++++++++++++++++++
+
+
+To modify the metadata that ``pyslim`` has introduced into 
+the tree sequence produced by a coalescent simulation,
+or the metadata in a SLiM-produced tree sequence,
+what we do is (a) extract the metadata (as a list of dicts),
+(b) modify them, and then (c) write them back into the tables.
 For instance, to set the ages of the individuals in the tree sequence to random numbers between 1 and 4,
 and write out the resulting tree sequence:
 
@@ -65,24 +97,27 @@ and write out the resulting tree sequence:
 
    import random
 
-   tables = new_ts.dump_tables()
-   ind_md = list(pyslim.extract_individual_metadata(tables))
-   for ind in ind_md:
-       ind.age = random.choice([1,2,3,4])
+   tables = ts.tables
+   ind_md = [ind.metadata for ind in tables.individuals]
+   for md in ind_md:
+       md["age"] = random.choice([1,2,3,4])
 
-   pyslim.annotate_individual_metadata(tables, ind_md)
+   ims = tables.individuals.metadata_schema
+   tables.individuals.packset_metadata(
+      [ims.validate_and_encode_row(md) for md in ind_md])
    mod_ts = pyslim.load_tables(tables, slim_format=True)
 
-   for ind in pyslim.extract_individual_metadata(mod_ts.tables):
-       print(ind.age)
+   # check that it worked:
+   for ind in mod_ts.individuals():
+       print(ind.metadata["age"])
 
+   # save out the tree sequence
    mod_ts.dump("modified_ts.trees")
 
 
 *****************
 Technical details
 *****************
-
 
 ++++++++++++++++
 Metadata entries
@@ -109,10 +144,93 @@ All remaining metadata are required (besides edges and sites, whose metadata is 
 Legacy metadata
 ===============
 
-TODO: fill this in
+In previous versions of pyslim,
+SLiM-specific metadata was provided as customized objects:
+for instance, for a node ``n`` provided by a ``SlimTreeSequence``,
+we'd have ``n.metadata`` as a ``NodeMetadata`` object,
+with attributes ``n.metadata.slim_id`` and ``n.metadata.is_null`` and ``n.metadata.genome_type``.
+However, with tskit 0.3, 
+the capacity to deal with structured metadata
+was implemented in `tskit itself <https://tskit.readthedocs.io/en/latest/metadata.html#sec-metadata>`_,
+and so pyslim shifted to using the tskit-native metadata tools.
+As a result, parsed metadata is provided as a dictionary instead of an object,
+so that now ``n.metadata`` would be a dict,
+with entries ``n.metadata["slim_id"]`` and ``n.metadata["is_null"]`` and ``n.metadata["genome_type"]``.
+Annotation should be done with tskit methods (e.g., ``packset_metadata``).
 
-Need to change
+For now, the old-style metadata is still available:
+passing the argument ``legacy_metadata=True`` to :meth:`load`
+will produce a tree sequence whose metadata is just as before,
+and so all previously-written scripts that depend on metadata processing should work, unchanged.
+Restating this:
 
-- `node.metadata.X` to `node.metadata["X"]`
-- `mutation.metadata[k].X` to `mutation.metadata["mutation_list"][k]["X"]`
-- `individual.metadata.population` to `individual.metadata["subpopulation"]` (note the *sub*)
+.. note::
+
+   To make an script that relied on previous metadata parsing work,
+   it should suffice to replace ``pyslim.load("file.trees")`` with
+   ``pyslim.load("file.trees", legacy_metadata=True)``.
+   If this fails, please file an issue on github.
+
+Here are more detailed notes on how to migrate a script from the legacy
+metadata handling.
+
+First, switch metadata objects to dicts:
+if ``md`` is the ``metadata`` property of a population, individual, or node,
+this means replacing ``md.X`` with ``md["X"]``.
+The ``migration_records`` property of population metadata is similarly
+a list of dicts rather than a list of objects, so instead of
+``ts.population(1).metadata.migration_records[0].source_subpop``
+we would write
+``ts.population(1).metadata["migration_records"][0]["source_subpop"]``.
+
+Mutations were previously a bit different - if ``mut`` is a mutation
+(e.g., ``mut = ts.mutation(0)``)
+then ``mut.metadata`` was previously a list of MutationMetadata objects.
+Now, ``mut.metadata`` is a dict, with a single entry:
+``mut.metadata["mutation_list"]`` is a list of dicts, each containing the information
+that was previously in the MutationMetadata objects.
+So, for instance, instead of ``mut.metadata[0].selection_coeff``
+we would write ``mut.metadata["mutation_list"][0]["selection_coeff"]``.
+
+Second, the ``decode_X`` and ``encode_X`` methods are now deprecated,
+as this is handled by tskit itself.
+For instance, ``encode_node`` would take a NodeMetadata object
+and produce the raw bytes necessary to encode it in a Node table,
+and ``decode_node`` would do the inverse operation.
+This is now handled by the relevant MetadataSchema object:
+for nodes one can obtain this as ``nms = ts.tables.nodes.metadata_schema``,
+which has the methods ``nms.validate_and_encode_row`` and ``nms.decode_row``.
+Decoding is for the most part not necessary,
+since the metadata is automatically decoded,
+but ``pyslim.decode_node(raw_md)`` could be replaced by ``nms.decode_row(raw_md)``.
+Encoding is necessary to modify tables,
+and ``pyslim.encode_node(md)`` can be replaced by ``nms.validate_and_encode_row(md)``
+(where furthermore ``md`` should now be a dict rather than a NodeMetadata object).
+
+Third, the ``annotate_X_metadata`` methods are deprecated,
+as again tskit has tools to do this.
+These methods would set the metadata column of a table -
+for instance, if ``metadata`` is a list of NodeMetadata objects, then
+``annotate_node_metadata(tables, metadata)`` would modify ``tables.nodes`` in place
+to contain the (encoded) metadata in the list ``metadata``.
+Now, this would be done as follows (where now ``metadata`` is a list of metadata dicts):
+
+.. code-block:: python
+
+   nms = tables.nodes.metadata_schema
+   tables.nodes.packset_metadata(
+      [nms.validate_and_encode_row(r) for r in metadata])
+
+If speed is an issue, then ``encode_row`` can be substituted for ``validate_and_encode_row``,
+but at the risk of missing errors in metadata.
+
+Fourth, the ``extract_X_metadata`` methods are not necessary,
+since the metadata in the tables of a TableCollection are automatically decoded.
+For instance, ``[ind.metadata["sex"] for ind in tables.individuals]`` will obtain
+a list of sexes of the individuals in the IndividualTable.
+
+.. warning::
+
+   It is our intention to remain backwards-compatible for a time.
+   However, the legacy code will disappear at some point in the future,
+   so please migrate over scripts you intend to rely on.

--- a/docs/python_api.rst
+++ b/docs/python_api.rst
@@ -33,45 +33,6 @@ Constants
    Nucleotide states in nucleotide models are encoded as integers (0, 1, 2, 3);
    this gives the mapping.
 
-
-********
-Metadata
-********
-
-SLiM-specific metadata is made visible to the user by ``.metadata`` properties.
-For instance::
-
-   >>> ts.node(3).metadata
-   NodeMetadata(slim_id=3, is_null=0, genome_type=0)
-
-shows that the fourth node in the tree sequence was given pedigree ID ``3`` by SLiM,
-is *not* a null genome, and has ``genome_type`` zero, which corresponds to an autosome 
-(see below).
-
-
-+++++++++
-Mutations
-+++++++++
-
-.. autoclass:: pyslim.MutationMetadata
-   :members:
-
-.. autofunction:: pyslim.decode_mutation
-
-.. autofunction:: pyslim.encode_mutation
-
-
-+++++
-Nodes
-+++++
-
-.. autoclass:: pyslim.NodeMetadata
-   :members:
-
-.. autofunction:: pyslim.decode_node
-
-.. autofunction:: pyslim.encode_node
-
 These constants are used to encode the "genome type" of a Node.
 
 .. data:: GENOME_TYPE_AUTOSOME == 0
@@ -81,19 +42,7 @@ These constants are used to encode the "genome type" of a Node.
 .. data:: GENOME_TYPE_Y == 2
 
 
-+++++++++++
-Individuals
-+++++++++++
-
-.. autoclass:: pyslim.IndividualMetadata
-   :members:
-
-.. autofunction:: pyslim.decode_individual
-
-.. autofunction:: pyslim.encode_individual
-
 These constants are used to encode other information about Individuals.
-
 
 .. data:: INDIVIDUAL_TYPE_HERMAPHRODITE == -1
 
@@ -113,26 +62,20 @@ And, these are used in the `Individual.flags`:
 
    This flag is used by SLiM to record information in the :class:`tskit.Individual` metadata.
 
-.. data:: INDIVIDUAL_FIRST_GEN == 2**18
 
-   This flag is used by SLiM to record information in the :class:`tskit.Individual` metadata.
+********
+Metadata
+********
 
+SLiM-specific metadata is made visible to the user by ``.metadata`` properties.
+For instance::
 
-+++++++++++
-Populations
-+++++++++++
+   >>> ts.node(3).metadata
+   {"slim_id" : 3, "is_null" : 0, "genome_type" : 0}
 
-The :class:`Population` metadata contains quite a bit of information about a SLiM population.
-
-.. autoclass:: pyslim.PopulationMigrationMetadata
-   :members:
-
-.. autoclass:: pyslim.PopulationMetadata
-   :members:
-
-.. autofunction:: pyslim.decode_population
-
-.. autofunction:: pyslim.encode_population
+shows that the fourth node in the tree sequence was given pedigree ID ``3`` by SLiM,
+is *not* a null genome, and has ``genome_type`` zero, which corresponds to an autosome 
+(see below).
 
 
 ++++++++++

--- a/docs/vignette_continuing.rst
+++ b/docs/vignette_continuing.rst
@@ -84,10 +84,10 @@ To "continue" the simulation neutrally, we'll
 a. simulate the desired period of time in msprime
 b. randomly match the initial ancestors in the msprime simulation
    with the final individuals of the SLim simulation, and
-c. merge the two together, using the `union( )` method.
+c. merge the two together, using the :meth:`tskit.TreeSequence.union` method.
 
 
-*(a)* Simulating for a given period of time in msprime just requires the `end_time` argument
+*(a)* Simulating for a given period of time in msprime just requires the ``end_time`` argument
 (remembering that this is *time ago*).
 We'll continue the simulation for another 1000 generations.
 
@@ -191,20 +191,20 @@ Let's do a sanity check:
 That matches up - the time of what should be the same node in the "continued" tree sequence
 is 1000 generations earlier.
 
-So, what happened with `union` back there?
-Well, the basic usage is `tables.union(other, node_map)`,
-where `node_map` is an array of length equal to the number of nodes in `other`,
-whose entries are either `tskit.NULL` or the ID of a node in `tables`.
+So, what happened with ``union`` back there?
+Well, the basic usage is ``tables.union(other, node_map)``,
+where ``node_map`` is an array of length equal to the number of nodes in ``other``,
+whose entries are either ``tskit.NULL`` or the ID of a node in ``tables``.
 The entries that *aren't* NULL indicate that
-`union` should glue together `tables` and `other` by saying that that pair of nodes are the same.
-(So, e.g., if `node_map[3]` is equal to `25`, then it says that node 25 in `tables`
-is actually the same, really, as node 3 in `other`.)
-We then asked `union` to please not create new populations,
+``union`` should glue together ``tables`` and ``other`` by saying that that pair of nodes are the same.
+(So, e.g., if ``node_map[3]`` is equal to ``25``, then it says that node 25 in ``tables``
+is actually the same, really, as node 3 in ``other``.)
+We then asked ``union`` to please not create new populations,
 since otherwise it would have assigned all the new nodes to a new population.
 We also asked it to not "check for overlap equality":
 sometimes, when unioning together two tree sequences,
 we really expect everything having to do with the set of nodes we're saying are identical
-to be identical in the two tree sequences, so `union` by default throws an error if it's not.
+to be identical in the two tree sequences, so ``union`` by default throws an error if it's not.
 We don't expect that in this case, because, for instance,
 there could be a mutation above one of the terminal nodes in the SLiM tree sequence;
 this would clearly not be present in the new tree sequence.

--- a/docs/vignette_space.rst
+++ b/docs/vignette_space.rst
@@ -148,7 +148,7 @@ Next, we will:
 
 We *won't* simplify, since we may as well keep around all the information.
 But, if we did (e.g., if we were running a large number of simulations),
-we would need to pass `keep_input_roots=True` to allow recapitation. 
+we would need to pass ``keep_input_roots=True`` to allow recapitation. 
 
 .. note::
 
@@ -183,9 +183,9 @@ resulting in
    tree sequence, so we need to convert it back, by wrapping the call to `mutate`
    in :func:`.SlimTreeSequence`.
 
-We will have no further use for `slim_ts` or for `recap_ts`;
+We will have no further use for ``slim_ts`` or for ``recap_ts``;
 we've just given them separate names for tidiness.
-And, since the original SLiM mutation had no mutations, we didn't need to specify `keep=True`
+And, since the original SLiM mutation had no mutations, we didn't need to specify ``keep=True``
 in :meth:`mutate <msprime.mutate>`, but if we *had* put down selected mutations with SLiM
 we'd probably want to keep them around.
 
@@ -242,10 +242,10 @@ We'll get genomes to work with by pulling out
 
 To keep names associated with each subset of individuals,
 we've kept the individuals in a dict, so that for instance
-`groups["topleft"]` is an array of all the individual IDs that are in the top left corner.
-The IDs of the ancient individuals we will work with are kept in the array `ancient`.
+``groups["topleft"]`` is an array of all the individual IDs that are in the top left corner.
+The IDs of the ancient individuals we will work with are kept in the array ``ancient``.
 
-Let's do a quick sanity check, that everyone in `ancient` was actually born around 1000 time steps ago:
+Let's do a quick sanity check, that everyone in ``ancient`` was actually born around 1000 time steps ago:
 
 .. code-block:: python
 
@@ -261,12 +261,12 @@ Plotting locations
 
 We should check this: plot where these individuals lie
 relative to everyone else.
-The individuals locations are available in individual metadata,
+The individuals locations are available as a property of individuals,
 but to make things easier, it's also present in a `num_individuals x 3`
-numpy array as `ts.individual_locations`.
+numpy array as ``ts.individual_locations``.
 (There are three columns because SLiM allows for
 `(x, y, z)` coordinates, but we'll just use the first two.)
-Since `groups["topleft"]` is an array of individual IDs,
+Since ``groups["topleft"]`` is an array of individual IDs,
 we can pull out the locations of the "topleft" individuals
 by indexing the rows of the individual location array:
 
@@ -345,21 +345,21 @@ For instance, here's what we have for the five "ancient" individuals:
    ... 
    {'id': 1346, 'flags': 131072, 'location': array([20.90314355,  3.20240965,  0.        ]),
     'nodes': array([1190, 1191], dtype=int32), 'population': 1, 'time': 1000.0,
-    'metadata': IndividualMetadata(pedigree_id=814660, age=0, population=1, sex=-1, flags=0)}
+    'metadata': {pedigree_id": 814660, age": 0, population": 1, sex": -1, flags": 0}}
    {'id': 1493, 'flags': 131072, 'location': array([12.26740846,  1.07346219,  0.        ]),
     'nodes': array([1484, 1485], dtype=int32), 'population': 1, 'time': 1000.0,
-    'metadata': IndividualMetadata(pedigree_id=814951, age=0, population=1, sex=-1, flags=0)}
+    'metadata': {"pedigree_id": 814951, "age": 0, "population": 1, "sex": -1, "flags": 0)}
    {'id': 791, 'flags': 131072, 'location': array([12.46965163, 24.09913306,  0.        ]),
     'nodes': array([80, 81], dtype=int32), 'population': 1, 'time': 1004.0,
-     'metadata': IndividualMetadata(pedigree_id=811245, age=4, population=1, sex=-1, flags=0)}
+     'metadata': {"pedigree_id": 811245, "age": 4, "population": 1, "sex": -1, "flags": 0)}
    {'id': 1239, 'flags': 131072, 'location': array([ 2.86034925, 23.946206  ,  0.        ]),
     'nodes': array([976, 977], dtype=int32), 'population': 1, 'time': 1000.0,
-    'metadata': IndividualMetadata(pedigree_id=814407, age=0, population=1, sex=-1, flags=0)}
+    'metadata': {"pedigree_id": 814407, "age": 0, "population": 1, "sex": -1, "flags": 0)}
    {'id': 782, 'flags': 131072, 'location': array([4.39645586, 9.4739672 , 0.        ]),
     'nodes': array([62, 63], dtype=int32), 'population': 1, 'time': 1004.0,
-    'metadata': IndividualMetadata(pedigree_id=811055, age=4, population=1, sex=-1, flags=0)}
+    'metadata': {"pedigree_id": 811055, "age": 4, "population": 1, "sex": -1, "flags": 0)}
 
-Notice that among other things, each `individual` carries around a list of their `node` IDs,
+Notice that among other things, each individual carries around a list of their node IDs,
 i.e., their genomes.
 We need to put these all in a list of lists,
 so that, for instance, the first element of the list will have the node IDs of all the genomes
@@ -473,7 +473,7 @@ Now let's plot genetic distance against geographic distance.
    :alt: Geographic and genetic distances in the simulation.
 
 
-Since we multiplied `ind_div` by 1,000,
+Since we multiplied ``ind_div`` by 1,000,
 the units of genetic distance are in mean number of nucleotide differences per kilobase.
 There is *not* strong IBD in this noisy and relatively small simulation,
 but notice that the "ancient" samples are more deeply diverged from modern samples (in yellow)
@@ -504,8 +504,8 @@ whose genomes we will write out to a VCF file.
            ind = ts.individual(i)
            vcf_label = f"tsk_{ind.id}"
            indivnames.append(vcf_label)
-           data = [vcf_label, str(ind.id), str(ind.metadata.pedigree_id), str(ind.time),
-                   str(ind.metadata.age), str(ind.location[0]), str(ind.location[1])]
+           data = [vcf_label, str(ind.id), str(ind.metadata["pedigree_id"]), str(ind.time),
+                   str(ind.metadata["age"]), str(ind.location[0]), str(ind.location[1])]
            indfile.writelines("\t".join(data) + "\n")
 
    with open("spatial_sim_genotypes.vcf", "w") as vcffile:

--- a/pyslim/slim_metadata.py
+++ b/pyslim/slim_metadata.py
@@ -459,7 +459,7 @@ def _set_metadata_schemas(tables):
 def _deprecation_warning():
     warnings.warn("This method will dissappear at some point, "
                   "along with all other old-style metadata tools: "
-                  "see `the documentation <https://pyslim.readthedocs.io/en/latest/metadata.html#sec-legacy-metadata>`_"
+                  "see `the documentation <https://pyslim.readthedocs.io/en/latest/metadata.html#legacy-metadata>`_"
                   "for more details.", DeprecationWarning)
 
 ###########

--- a/pyslim/slim_metadata.py
+++ b/pyslim/slim_metadata.py
@@ -2,6 +2,7 @@ import attr
 import struct
 import tskit
 import json
+import warnings
 
 from ._version import *
 
@@ -398,6 +399,7 @@ default_slim_metadata = {
     },
 }
 
+
 ###########
 # Top-level, a.k.a., tree sequence metadata
 ###########
@@ -449,6 +451,16 @@ def _set_metadata_schemas(tables):
     tables.individuals.metadata_schema = slim_metadata_schemas['individual']
     tables.populations.metadata_schema = slim_metadata_schemas['population']
 
+
+
+################################
+# Old-style metadata:
+
+def _deprecation_warning():
+    warnings.warn("This method will dissappear at some point, "
+                  "along with all other old-style metadata tools: "
+                  "see `the documentation <https://pyslim.readthedocs.io/en/latest/metadata.html#sec-legacy-metadata>`_"
+                  "for more details.", DeprecationWarning)
 
 ###########
 # Mutations
@@ -509,10 +521,16 @@ def decode_mutation(buff):
     a given "mutation" as recorded in tskit may actually represent a
     combination of several SLiM mutations.
 
+    .. warning::
+
+        This method is deprecated, since metadata handling has been taken over
+        by tskit. It will dissappear at some point in the future.
+
     :param bytes buff: The ``metadata`` entry of a row of a
         :class:`MutationTable`, as stored by SLiM.
     :rtype list:
     '''
+    _deprecation_warning()
     if type(buff) == type([]) and (len(buff) == 0
             or type(buff[0]) == MutationMetadata):
         mut_structs = buff
@@ -588,10 +606,16 @@ def encode_mutation(metadata_object):
     functions, this takes a *list* rather than a single value, thanks to
     stacking of SLiM mutations.
 
+    .. warning::
+
+        This method is deprecated, since metadata handling has been taken over
+        by tskit. It will dissappear at some point in the future.
+
     :param MutationMetadata metadata_object: The list of
         :class:`MutationMetadata` objects to be encoded.
     :rtype bytes:
     '''
+    _deprecation_warning()
     mr_values = []
     for mr in metadata_object:
         mr_values.extend([mr.mutation_type, mr.selection_coeff,
@@ -605,8 +629,14 @@ def extract_mutation_metadata(tables):
     Returns an iterator over lists of :class:`MutationMetadata` objects containing
     information about the mutations in the tables.
 
+    .. warning::
+
+        This method is deprecated, since metadata handling has been taken over
+        by tskit. It will dissappear at some point in the future.
+
     :param TableCollection tables: The tables, as produced by SLiM.
     '''
+    _deprecation_warning()
     metadata = tskit.unpack_bytes(tables.mutations.metadata,
                                     tables.mutations.metadata_offset)
     for mut in tables.mutations:
@@ -618,20 +648,24 @@ def annotate_mutation_metadata(tables, metadata):
     Revise the mutation table in place so that the metadata column is given by
     applying `encode_mutation()` to the sources given.
 
+    .. warning::
+
+        This method is deprecated, since metadata handling has been taken over
+        by tskit. It will dissappear at some point in the future.
+
     :param TableCollection tables: a table collection to be modified
     :param iterable metadata: a list of (lists of MutationMetadata) or None objects
     '''
+    _deprecation_warning()
     if len(metadata) != tables.mutations.num_rows:
         raise ValueError("annotate mutations: metadata not the same length as the table.")
     orig_mutations = tables.mutations.copy()
     tables.mutations.clear()
     for mut, md in zip(orig_mutations, metadata):
-        if md is None:
-            metadata = default_slim_metadata['mutation']
-        else:
-            metadata = {'mutation_list': [mm.asdict() for mm in md]}
+        if md is not None:
+            md = {'mutation_list': [mm.asdict() for mm in md]}
         tables.mutations.add_row(site=mut.site, node=mut.node, derived_state=mut.derived_state,
-                                 parent=mut.parent, time=mut.time, metadata=metadata)
+                                 parent=mut.parent, time=mut.time, metadata=md)
 
 
 #######
@@ -681,10 +715,16 @@ def decode_node(buff):
     Extracts the information stored in binary by SLiM in the ``metadata``
     column of a :class:`NodeTable`.  If the buffer is empty, returns None.
 
+    .. warning::
+
+        This method is deprecated, since metadata handling has been taken over
+        by tskit. It will dissappear at some point in the future.
+
     :param bytes buff: The ``metadata`` entry of a row of a
         :class:`NodeTable`, as stored by SLiM.
     :rtype NodeMetadata:
     '''
+    _deprecation_warning()
     if type(buff) == NodeMetadata:
         md = buff
     else:
@@ -711,9 +751,15 @@ def encode_node(metadata_object):
     in as metadata for a node. If ``metadata_object`` is ``None``, returns an
     empty bytes object.
 
+    .. warning::
+
+        This method is deprecated, since metadata handling has been taken over
+        by tskit. It will dissappear at some point in the future.
+
     :param NodeMetadata metadata_object: The object to be encoded.
     :rtype bytes:
     '''
+    _deprecation_warning()
     if metadata_object is None:
         md = b''
     else:
@@ -727,8 +773,14 @@ def extract_node_metadata(tables):
     Returns an iterator over lists of :class: `NodeMetadata` objects containing
     information about the nodes in the tables.
 
+    .. warning::
+
+        This method is deprecated, since metadata handling has been taken over
+        by tskit. It will dissappear at some point in the future.
+
     :param TableCollection tables: The tables, as produced by SLiM.
     '''
+    _deprecation_warning()
     for n in tables.nodes:
         yield NodeMetadata.fromdict(n.metadata)
 
@@ -738,20 +790,22 @@ def annotate_node_metadata(tables, metadata):
     Modify the NodeTable so that the metadata
     column is given by applying `encode_node()` to the sources given.
 
+    .. warning::
+
+        This method is deprecated, since metadata handling has been taken over
+        by tskit. It will dissappear at some point in the future.
+
     :param TableCollection tables: a table collection to be modified
     :param iterable metadata: a list of NodeMetadata or None objects
     '''
+    _deprecation_warning()
     if len(metadata) != tables.nodes.num_rows:
         raise ValueError("annotate nodes: metadata not the same length as the table.")
     orig_nodes = tables.nodes.copy()
     tables.nodes.clear()
     for node, md in zip(orig_nodes, metadata):
-        if md is None:
-            metadata = None
-        else:
-            metadata = md.asdict()
         tables.nodes.add_row(flags=node.flags, time=node.time, population=node.population,
-                             individual=node.individual, metadata=metadata)
+                             individual=node.individual, metadata=md.asdict())
 
 
 #######
@@ -805,10 +859,16 @@ def decode_individual(buff):
     Extracts the information stored in binary by SLiM in the ``metadata``
     column of a :class:`IndividualTable`. If the buffer is empty, returns None.
 
+    .. warning::
+
+        This method is deprecated, since metadata handling has been taken over
+        by tskit. It will dissappear at some point in the future.
+
     :param bytes buff: The ``metadata`` entry of a row of a
         :class:`IndividualTable`, as stored by SLiM.
     :rtype IndividualMetadata:
     '''
+    _deprecation_warning()
     if type(buff) == IndividualMetadata:
         md = buff
     else:
@@ -836,9 +896,15 @@ def encode_individual(metadata_object):
     in as metadata for an individual.  If ``buff`` is ``None``, returns an
     empty bytes object.
 
+    .. warning::
+
+        This method is deprecated, since metadata handling has been taken over
+        by tskit. It will dissappear at some point in the future.
+
     :param IndividualMetadata metadata_object: The object to be encoded.
     :rtype bytes:
     '''
+    _deprecation_warning()
     if metadata_object is None:
         md = b''
     else:
@@ -853,8 +919,14 @@ def extract_individual_metadata(tables):
     Returns an iterator over lists of :class:`IndividualMetadata` objects
     containing information about the individuals in the tables.
 
+    .. warning::
+
+        This method is deprecated, since metadata handling has been taken over
+        by tskit. It will dissappear at some point in the future.
+
     :param TableCollection tables: The tables, as produced by SLiM.
     '''
+    _deprecation_warning()
     for ind in tables.individuals:
         yield IndividualMetadata.fromdict(ind.metadata)
 
@@ -864,19 +936,23 @@ def annotate_individual_metadata(tables, metadata):
     Modify the IndividualTable so that the metadata
     column is given by applying `encode_individual()` to the sources given.
 
+    .. warning::
+
+        This method is deprecated, since metadata handling has been taken over
+        by tskit. It will dissappear at some point in the future.
+
     :param TableCollection tables: a table collection to be modified
     :param iterable metadata: a list of IndividualMetadata or None objects
     '''
+    _deprecation_warning()
     if len(metadata) != tables.individuals.num_rows:
         raise ValueError("annotate individuals: metadata not the same length as the table.")
     orig_individuals = tables.individuals.copy()
     tables.individuals.clear()
     for ind, md in zip(orig_individuals, metadata):
         if md is None:
-            metadata = default_slim_metadata['individual']
-        else:
-            metadata = md.asdict()
-        tables.individuals.add_row(flags=ind.flags, location=ind.location, metadata=metadata)
+            md = default_slim_metadata['individual']
+        tables.individuals.add_row(flags=ind.flags, location=ind.location, metadata=md.asdict())
 
 #######
 # Populations
@@ -980,10 +1056,16 @@ def decode_population(buff):
     Extracts the information stored in binary by SLiM in the ``metadata``
     column of a :class:`PopulationTable`. If the buffer is empty, returns None.
 
+    .. warning::
+
+        This method is deprecated, since metadata handling has been taken over
+        by tskit. It will dissappear at some point in the future.
+
     :param bytes buff: The ``metadata`` entry of a row of a
         :class:`PopulationTable`, as stored by SLiM.
     :rtype PopulationMetadata:
     '''
+    _deprecation_warning()
     if type(buff) == PopulationMetadata:
         md = buff
     else:
@@ -1042,9 +1124,15 @@ def encode_population(metadata_object):
     in as metadata for a population.  If ``buff`` is ``None``, returns an empty
     bytes object.
 
+    .. warning::
+
+        This method is deprecated, since metadata handling has been taken over
+        by tskit. It will dissappear at some point in the future.
+
     :param PopulationMetadata metadata_object: The object to be encoded.
     :rtype bytes:
     '''
+    _deprecation_warning()
     if metadata_object is None:
         md = b''
     else:
@@ -1069,8 +1157,14 @@ def extract_population_metadata(tables):
     Returns an iterator over lists of :class:`PopulationMetadata` objects
     containing information about the populations in the tables.
 
+    .. warning::
+
+        This method is deprecated, since metadata handling has been taken over
+        by tskit. It will dissappear at some point in the future.
+
     :param TableCollection tables: The tables, as produced by SLiM.
     '''
+    _deprecation_warning()
     for pop in tables.populations:
         yield PopulationMetadata.fromdict(pop.metadata)
 
@@ -1081,16 +1175,20 @@ def annotate_population_metadata(tables, metadata):
     column is given by applying `encode_population()` to the sources given.
     This entirely removes existing information in the Population table.
 
+    .. warning::
+
+        This method is deprecated, since metadata handling has been taken over
+        by tskit. It will dissappear at some point in the future.
+
     :param TableCollection tables: a table collection to be modified
     :param iterable metadata: a list of objects, each PopulationMetadata or None
     '''
+    _deprecation_warning()
     if len(metadata) != tables.populations.num_rows:
         raise ValueError("annotate populations: metadata not the same length as the table.")
     tables.populations.clear()
     for md in metadata:
-        if md is None:
-            metadata = None
-        else:
-            metadata = md.asdict()
-        tables.populations.add_row(metadata=metadata)
+        if md is not None:
+            md = md.asdict()
+        tables.populations.add_row(metadata=md)
 

--- a/pyslim/slim_tree_sequence.py
+++ b/pyslim/slim_tree_sequence.py
@@ -98,7 +98,7 @@ class MetadataDictWrapper(dict):
                     f"'dict' object has no attribute '{name}'. "
                     "It looks like you're trying to use the legacy "
                     "metadata interface: see "
-                    "`the documentation <https://pyslim.readthedocs.io/en/latest/metadata.html#sec-legacy-metadata>`_ "
+                    "`the documentation <https://pyslim.readthedocs.io/en/latest/metadata.html#legacy-metadata>`_ "
                     "for how to switch over your script")
         else:
             raise AttributeError(f"'dict' object has no attribute '{name}'")
@@ -111,7 +111,7 @@ class MetadataDictWrapper(dict):
                 msg = e.args[0]
                 e.args = (f"{msg}: It looks like you're trying to use the legacy "
                            "metadata interface: see "
-                           "`the documentation <https://pyslim.readthedocs.io/en/latest/metadata.html#sec-legacy-metadata>`_ "
+                           "`the documentation <https://pyslim.readthedocs.io/en/latest/metadata.html#legacy-metadata>`_ "
                            "for how to switch over your script",)
             raise e
 
@@ -143,7 +143,7 @@ class SlimTreeSequence(tskit.TreeSequence):
         length that gives the entire reference sequence for nucleotide models.
     :ivar legacy_metadata: Whether this tree sequence returns metadata in objects
         (as in older versions of pyslim) rather than dicts: see
-        `the documentation <https://pyslim.readthedocs.io/en/latest/metadata.html#sec-legacy-metadata>`_.
+        `the documentation <https://pyslim.readthedocs.io/en/latest/metadata.html#legacy-metadata>`_.
         This option is deprecated and will disappear at some point.
     :vartype slim_generation: int
     :vartype reference_sequence: string

--- a/pyslim/slim_tree_sequence.py
+++ b/pyslim/slim_tree_sequence.py
@@ -914,7 +914,7 @@ def _set_nodes_individuals(
             zip(ind_id, age, ind_population, ind_sex, slim_ind_flags)]
     assert(len(individual_metadata) == num_individuals)
     individual_metadata, individual_metadata_offset = tskit.pack_bytes(
-            [ims.validate_and_encode_row(r) for r in individual_metadata])
+            [ims.encode_row(r) for r in individual_metadata])
     tables.individuals.set_columns(
             flags=ind_flags, location=loc_vec, location_offset=loc_off,
             metadata=individual_metadata,
@@ -929,7 +929,7 @@ def _set_nodes_individuals(
                             }
     nms = tables.nodes.metadata_schema
     node_metadata, node_metadata_offset = tskit.pack_bytes(
-            [nms.validate_and_encode_row(r) for r in node_metadata])
+            [nms.encode_row(r) for r in node_metadata])
     tables.nodes.set_columns(flags=tables.nodes.flags, time=tables.nodes.time,
                              population=tables.nodes.population, individual=node_ind,
                              metadata=node_metadata,
@@ -1023,7 +1023,7 @@ def _set_populations(
                 migration_records)]
     ms = tables.populations.metadata_schema
     tables.populations.packset_metadata(
-            [ms.validate_and_encode_row(r) for r in population_metadata])
+            [ms.encode_row(r) for r in population_metadata])
 
 
 def _set_sites_mutations(
@@ -1077,4 +1077,4 @@ def _set_sites_mutations(
                          zip(mutation_type, selection_coeff, population, slim_time)]
     ms = tables.mutations.metadata_schema
     tables.mutations.packset_metadata(
-            [ms.validate_and_encode_row(r) for r in mutation_metadata])
+            [ms.encode_row(r) for r in mutation_metadata])

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -63,10 +63,10 @@ for f in restart_files:
     restart_files[f]['basename'] = os.path.join("tests", "examples", f)
 
 
-def run_slim_script(slimfile, **kwargs):
+def run_slim_script(slimfile, seed=23, **kwargs):
     outdir = os.path.dirname(slimfile)
     script = os.path.basename(slimfile)
-    args = ''
+    args = f"-s {seed}"
     for k in kwargs:
         x = kwargs[k]
         if x is not None:
@@ -75,8 +75,9 @@ def run_slim_script(slimfile, **kwargs):
             if isinstance(x, bool):
                 x = 'T' if x else 'F'
             args += f" -d \"{k}={x}\""
-    print("running " + "cd " + outdir + " && slim -s 23 " + args + " " + script)
-    out = os.system("cd " + outdir + " && slim -s 23 " + args + " " + script + ">/dev/null")
+    command = "cd \"" + outdir + "\" && slim " + args + " \"" + script + "\" >/dev/null"
+    print("running: ", command)
+    out = os.system(command)
     return out
 
 

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -210,16 +210,21 @@ class PyslimTestCase(unittest.TestCase):
         return out_ts
 
     def get_msprime_examples(self):
+        # NOTE: we use DTWF below to avoid rounding of floating-point times
+        # that occur with a continuous-time simulator
         demographic_events = [
             msprime.MassMigration(
             time=5, source=1, destination=0, proportion=1.0)
         ]
+        seed = 6
         for n in [2, 10, 20]:
             for mutrate in [0.0]:
                 for recrate in [0.0, 0.01]:
                     yield msprime.simulate(n, mutation_rate=mutrate,
                                            recombination_rate=recrate,
-                                           length=200)
+                                           length=200, random_seed=seed,
+                                           model="dtwf")
+                    seed += 1
                     population_configurations =[
                         msprime.PopulationConfiguration(
                         sample_size=n, initial_size=100),
@@ -231,7 +236,9 @@ class PyslimTestCase(unittest.TestCase):
                         demographic_events=demographic_events,
                         recombination_rate=recrate,
                         mutation_rate=mutrate,
-                        length=250)
+                        length=250, random_seed=seed,
+                        model="dtwf")
+                    seed += 1
 
     def get_slim_info(self, fname):
         # returns a dictionary whose keys are SLiM individual IDs, and whose values
@@ -295,11 +302,57 @@ class PyslimTestCase(unittest.TestCase):
         md2 = t2._ll_tables.metadata
         self.assertEqual(md1, md2)
 
-    def assertTableCollectionsEqual(self, t1, t2, skip_provenance=False, check_metadata_schema=True):
+    def verify_trees_equal(self, ts1, ts2):
+        # check that trees are equal by checking MRCAs between randomly
+        # chosen nodes with matching slim_ids
+        random.seed(23)
+        self.assertEqual(ts1.sequence_length, ts2.sequence_length)
+        if isinstance(ts1, tskit.TableCollection):
+            ts1 = ts1.tree_sequence()
+        if isinstance(ts2, tskit.TableCollection):
+            ts2 = ts2.tree_sequence()
+        map1 = {}
+        for j, n in enumerate(ts1.nodes()):
+            if n.metadata is not None:
+                map1[n.metadata['slim_id']] = j
+        map2 = {}
+        for j, n in enumerate(ts2.nodes()):
+            if n.metadata is not None:
+                map2[n.metadata['slim_id']] = j
+        self.assertEqual(set(map1.keys()), set(map2.keys()))
+        sids = list(map1.keys())
+        for sid in sids:
+            n1 = ts1.node(map1[sid])
+            n2 = ts2.node(map2[sid])
+            self.assertEqual(n1.time, n2.time)
+            self.assertEqual(n1.metadata, n2.metadata)
+            i1 = ts1.individual(n1.individual)
+            i2 = ts2.individual(n2.individual)
+            self.assertEqual(i1.metadata, i2.metadata)
+        for _ in range(10):
+            pos = random.uniform(0, ts1.sequence_length)
+            t1 = ts1.at(pos)
+            t2 = ts2.at(pos)
+            for _ in range(10):
+                a, b = random.choices(sids, k=2)
+                self.assertEqual(t1.tmrca(map1[a], map1[b]),
+                                 t2.tmrca(map2[a], map2[b]))
+
+    def assertTableCollectionsEqual(self, t1, t2,
+            skip_provenance=False, check_metadata_schema=True,
+            reordered_individuals=False):
         if isinstance(t1, tskit.TreeSequence):
             t1 = t1.tables
         if isinstance(t2, tskit.TreeSequence):
             t2 = t2.tables
+        t1_samples = [(n.metadata['slim_id'], j) for j, n in enumerate(t1.nodes) if (n.flags & tskit.NODE_IS_SAMPLE)]
+        t1_samples.sort()
+        t2_samples = [(n.metadata['slim_id'], j) for j, n in enumerate(t2.nodes) if (n.flags & tskit.NODE_IS_SAMPLE)]
+        t2_samples.sort()
+        print('1', t1_samples)
+        print('2', t2_samples)
+        t1.simplify([j for (_, j) in t1_samples])
+        t2.simplify([j for (_, j) in t2_samples])
         if skip_provenance is True:
             t1.provenances.clear()
             t2.provenances.clear()
@@ -341,6 +394,23 @@ class PyslimTestCase(unittest.TestCase):
             t1.metadata = b''
             t2.metadata = b''
             self.assertEqual(m1, m2)
+        if reordered_individuals:
+            ind1 = {i.metadata['pedigree_id']: j for j, i in enumerate(t1.individuals)}
+            ind2 = {i.metadata['pedigree_id']: j for j, i in enumerate(t2.individuals)}
+            for pid in ind1:
+                if not pid in ind2:
+                    print("not in t2:", ind1[pid])
+                self.assertTrue(pid in ind2)
+                if t1.individuals[ind1[pid]] != t2.individuals[ind2[pid]]:
+                    print("t1:", t1.individuals[ind1[pid]])
+                    print("t2:", t2.individuals[ind2[pid]])
+                self.assertEqual(t1.individuals[ind1[pid]], t2.individuals[ind2[pid]])
+            for pid in ind2:
+                if not pid in ind1:
+                    print("not in t1:", ind2[pid])
+                self.assertTrue(pid in ind1)
+            t1.individuals.clear()
+            t2.individuals.clear()
         # go through one-by-one so we know which fails
         self.assertTablesEqual(t1.populations, t2.populations, "populations")
         self.assertTablesEqual(t1.individuals, t2.individuals, "individuals")

--- a/tests/recipes/Makefile
+++ b/tests/recipes/Makefile
@@ -1,0 +1,94 @@
+export SHELL=/bin/bash
+.PRECIOUS : recipe_17.4.trees
+
+check : recipe_17.1_overlaid.log recipe_17.3.log recipe_17.4.png recipe_17.5.png recipe_17.7.log recipe_17.8_III.log recipe_17.9.log recipe_nucleotides_II.log recipe_nucleotides_III.log
+	echo "-------------"
+	echo "17.1 + 17.2"
+	cat recipe_17.1_overlaid.log
+	echo "-------------"
+	echo "17.3"
+	cat recipe_17.3.log
+	echo "-------------"
+	echo "17.4"
+	eog recipe_17.4.png
+	echo "-------------"
+	echo "17.5"
+	eog recipe_17.5.png
+	echo "-------------"
+	echo "17.7"
+	cat recipe_17.7.log
+	echo "-------------"
+	echo "17.8"
+	head  recipe_17.8_III.log
+	echo "(snipped $$(wc -l recipe_17.8_III.log) lines)"
+	echo "-------------"
+	echo "17.9"
+	cat recipe_17.9.log 
+	echo "-------------"
+	echo "18.13 II"
+	cat recipe_nucleotides_II.log
+	echo "-------------"
+	echo "18.13 III"
+	head recipe_nucleotides_III.log
+	echo "(snipped $$(wc -l recipe_nucleotides_III.log) lines)"
+	echo "-------------"
+
+clean :
+	-rm -f *.trees *.log *.png
+
+recipe_17.1.trees : Recipe\ 17.1\ -\ A\ minimal\ tree-seq\ model.txt
+	slim -s 0 "$<" &> $@.log
+
+recipe_17.1_overlaid.trees : Recipe\ 17.2\ -\ Overlaying\ neutral\ mutations.py recipe_17.1.trees
+	python3 "$<"
+
+recipe_17.1_overlaid.log : recipe_17.1_overlaid.trees
+	./check_trees.py $< > $@
+
+slim_2345_FIXED.trees : Recipe\ 17.3\ -\ Simulation\ conditional\ upon\ fixation\ of\ a\ sweep,\ preserving\ ancestry\ II.txt
+	slim -s 2345 "$<" &> $@.log
+
+recipe_17.3.log : slim_2345_FIXED.trees
+	./check_trees.py $< > $@
+
+recipe_17.4.trees : Recipe\ 17.4\ -\ Detecting\ the\ "dip\ in\ diversity"\ (analyzing\ tree\ heights\ in\ Python)\ I.txt
+	slim -s 2345 '$<' &> $@.log
+
+recipe_17.4.png : Recipe\ 17.4\ -\ Detecting\ the\ "dip\ in\ diversity"\ (analyzing\ tree\ heights\ in\ Python)\ II.py recipe_17.4.trees
+	python3 '$<'
+
+recipe_17.5.trees: Recipe\ 17.5\ -\ Mapping\ admixture\ (analyzing\ ancestry\ in\ Python)\ I.txt
+	slim -s 2345 "$<" &> $@.log
+
+recipe_17.5.png : Recipe\ 17.5\ -\ Mapping\ admixture\ (analyzing\ ancestry\ in\ Python)\ II.py recipe_17.5.trees
+	python3 "$<"
+
+recipe_17.7.trees : Recipe\ 17.7\ -\ Analyzing\ selection\ coefficients\ in\ Python\ with\ pyslim\ I.txt
+	slim -s 2345 "$<" &> $@.log
+
+recipe_17.7.log : Recipe\ 17.7\ -\ Analyzing\ selection\ coefficients\ in\ Python\ with\ pyslim\ II.py recipe_17.7.trees
+	python3 "$<" &> $@
+
+recipe_17.8.trees : Recipe\ 17.8\ -\ Starting\ a\ hermaphroditic\ WF\ model\ with\ a\ coalescent\ history\ I.py
+	python3 "$<"
+
+recipe_17.8_II.trees : Recipe\ 17.8\ -\ Starting\ a\ hermaphroditic\ WF\ model\ with\ a\ coalescent\ history\ II.txt recipe_17.8.trees
+	slim -s 2345 "$<" &> $@.log
+
+recipe_17.8_III.log : Recipe\ 17.8\ -\ Starting\ a\ hermaphroditic\ WF\ model\ with\ a\ coalescent\ history\ III.py recipe_17.8_II.trees
+	python3 "$<" &> $@
+
+recipe_17.9.trees : Recipe\ 17.9\ -\ Starting\ a\ sexual\ nonWF\ model\ with\ a\ coalescent\ history\ I.py
+	python3 "$<"
+
+recipe_17.9.log : Recipe\ 17.9\ -\ Starting\ a\ sexual\ nonWF\ model\ with\ a\ coalescent\ history\ II.txt recipe_17.9.trees
+	slim -s 2345 "$<" &> $@
+
+recipe_nucleotides.trees : Recipe\ 18.13\ -\ Tree-sequence\ recording\ and\ nucleotide-based\ models\ I.txt
+	slim -s 2345 "$<" &> $@.log
+
+recipe_nucleotides_II.log : Recipe\ 18.13\ -\ Tree-sequence\ recording\ and\ nucleotide-based\ models\ II.py recipe_nucleotides.trees
+	python3 "$<" &> $@
+
+recipe_nucleotides_III.log : Recipe\ 18.13\ -\ Tree-sequence\ recording\ and\ nucleotide-based\ models\ III.py recipe_nucleotides.trees
+	python3 "$<" &> $@

--- a/tests/recipes/Recipe 17.1 - A minimal tree-seq model.txt
+++ b/tests/recipes/Recipe 17.1 - A minimal tree-seq model.txt
@@ -1,0 +1,20 @@
+// Keywords: tree-sequence recording, tree sequence recording
+
+initialize() {
+	initializeTreeSeq();
+	initializeMutationRate(0);
+	initializeMutationType("m1", 0.5, "f", 0.0);
+	initializeGenomicElementType("g1", m1, 1.0);
+	initializeGenomicElement(g1, 0, 1e8-1);
+	initializeRecombinationRate(1e-8);
+}
+1 {
+	sim.addSubpop("p1", 500);
+}
+5000 late() {
+	sim.treeSeqOutput("./recipe_17.1.trees");
+}
+
+// Section 17.2's recipe, which is a Python script that overlays
+// neutral mutations onto the .trees file saved here, may be found in
+// the Recipes archive downloadable at https://messerlab.org/slim/

--- a/tests/recipes/Recipe 17.10 - Adding a neutral burn-in after simulation with recapitation I.txt
+++ b/tests/recipes/Recipe 17.10 - Adding a neutral burn-in after simulation with recapitation I.txt
@@ -1,0 +1,30 @@
+// Keywords: tree-sequence recording, tree sequence recording
+
+initialize() {
+	initializeTreeSeq(simplificationRatio=INF);
+	initializeMutationRate(0);
+	initializeMutationType("m2", 0.5, "f", 1.0);
+	m2.convertToSubstitution = F;
+	initializeGenomicElementType("g1", m2, 1);
+	initializeGenomicElement(g1, 0, 1e6 - 1);
+	initializeRecombinationRate(3e-10);
+}
+1 late() {
+	sim.addSubpop("p1", 1e5);
+}
+100 late() {
+	sample(p1.genomes, 1).addNewDrawnMutation(m2, 5e5);
+}
+100:10000 late() {
+	mut = sim.mutationsOfType(m2);
+	if (mut.size() != 1)
+		stop(sim.generation + ": LOST");
+	else if (sum(sim.mutationFrequencies(NULL, mut)) == 1.0)
+	{
+		sim.treeSeqOutput("recipe_17.10_decap.trees");
+		sim.simulationFinished();
+	}
+}
+
+// Part II of this recipe, which is a Python script, may be found in
+// the Recipes archive downloadable at https://messerlab.org/slim/

--- a/tests/recipes/Recipe 17.10 - Adding a neutral burn-in after simulation with recapitation II.py
+++ b/tests/recipes/Recipe 17.10 - Adding a neutral burn-in after simulation with recapitation II.py
@@ -1,0 +1,38 @@
+# Keywords: Python, tree-sequence recording, tree sequence recording
+
+import msprime, pyslim
+import numpy as np
+import matplotlib.pyplot as plt
+
+# Load the .trees file
+ts = pyslim.load("recipe_17.10_decap.trees")    # no simplify!
+
+# Calculate tree heights, giving uncoalesced sites the maximum time
+def tree_heights(ts):
+    heights = np.zeros(ts.num_trees + 1)
+    for tree in ts.trees():
+        if tree.num_roots > 1:  # not fully coalesced
+            heights[tree.index] = ts.slim_generation
+        else:
+            children = tree.children(tree.root)
+            real_root = tree.root if len(children) > 1 else children[0]
+            heights[tree.index] = tree.time(real_root)
+    heights[-1] = heights[-2]  # repeat the last entry for plotting with step
+    return heights
+
+# Plot tree heights before recapitation
+breakpoints = list(ts.breakpoints())
+heights = tree_heights(ts)
+plt.step(breakpoints, heights, where='post')
+plt.show()
+
+# Recapitate!
+recap = ts.recapitate(recombination_rate=3e-10, Ne=1e5, random_seed=1)
+recap.dump("recipe_17.10_recap.trees")
+
+# Plot the tree heights after recapitation
+breakpoints = list(recap.breakpoints())
+heights = tree_heights(recap)
+plt.step(breakpoints, heights, where='post')
+plt.show()
+

--- a/tests/recipes/Recipe 17.2 - Overlaying neutral mutations.py
+++ b/tests/recipes/Recipe 17.2 - Overlaying neutral mutations.py
@@ -1,0 +1,20 @@
+# Keywords: Python, tree-sequence recording, tree sequence recording
+
+# This is a Python recipe, to be run after the section 17.1 recipe
+
+import msprime, pyslim
+
+ts = pyslim.load("./recipe_17.1.trees").simplify()
+
+## EDIT FOR TESTING
+asserted = False
+try:
+    for t in ts.trees():
+        assert t.num_roots == 1, "not coalesced! on segment {} to {}".format(t.interval[0], t.interval[1])
+except AssertionError:
+    asserted = True
+
+assert asserted
+
+mutated = msprime.mutate(ts, rate=1e-7, random_seed=1, keep=True)
+mutated.dump("./recipe_17.1_overlaid.trees")

--- a/tests/recipes/Recipe 17.3 - Simulation conditional upon fixation of a sweep, preserving ancestry I.txt
+++ b/tests/recipes/Recipe 17.3 - Simulation conditional upon fixation of a sweep, preserving ancestry I.txt
@@ -1,0 +1,33 @@
+// Keywords: tree-sequence recording, tree sequence recording, conditional sweep
+
+initialize() {
+	initializeMutationRate(1e-7);
+	initializeMutationType("m1", 0.5, "f", 0.0);
+	initializeMutationType("m2", 0.5, "g", -0.01, 1.0);  // deleterious
+	initializeMutationType("m3", 1.0, "f", 0.05);        // introduced
+	initializeGenomicElementType("g1", c(m1, m2), c(0.9, 0.1));
+	initializeGenomicElement(g1, 0, 99999);
+	initializeRecombinationRate(1e-8);
+}
+1 {
+	defineConstant("simID", getSeed());
+	sim.addSubpop("p1", 500);
+}
+1000 late() {
+	target = sample(p1.genomes, 1);
+	target.addNewDrawnMutation(m3, 10000);
+	sim.outputFull("/tmp/slim_" + simID + ".txt");
+}
+1000:100000 late() {
+	if (sim.countOfMutationsOfType(m3) == 0) {
+		if (sum(sim.substitutions.mutationType == m3) == 1) {
+			cat(simID + ": FIXED\n");
+			sim.simulationFinished();
+		} else {
+			cat(simID + ": LOST - RESTARTING\n");
+			
+			sim.readFromPopulationFile("/tmp/slim_" + simID + ".txt");
+			setSeed(rdunif(1, 0, asInteger(2^62) - 1));
+		}
+	}
+}

--- a/tests/recipes/Recipe 17.3 - Simulation conditional upon fixation of a sweep, preserving ancestry II.txt
+++ b/tests/recipes/Recipe 17.3 - Simulation conditional upon fixation of a sweep, preserving ancestry II.txt
@@ -1,0 +1,34 @@
+// Keywords: tree-sequence recording, tree sequence recording, conditional sweep
+
+initialize() {
+	initializeTreeSeq();
+	initializeMutationRate(1e-8);
+	initializeMutationType("m2", 0.5, "g", -0.01, 1.0);  // deleterious
+	initializeMutationType("m3", 1.0, "f", 0.05);        // introduced
+	initializeGenomicElementType("g1", m2, 1.0);
+	initializeGenomicElement(g1, 0, 99999);
+	initializeRecombinationRate(1e-8);
+}
+1 {
+	defineConstant("simID", getSeed());
+	sim.addSubpop("p1", 500);
+}
+1000 late() {
+	target = sample(p1.genomes, 1);
+	target.addNewDrawnMutation(m3, 10000);
+	sim.treeSeqOutput("/tmp/slim_" + simID + ".trees");
+}
+1000:100000 late() {
+	if (sim.countOfMutationsOfType(m3) == 0) {
+		if (sum(sim.substitutions.mutationType == m3) == 1) {
+			cat(simID + ": FIXED\n");
+			sim.treeSeqOutput("slim_" + simID + "_FIXED.trees");
+			sim.simulationFinished();
+		} else {
+			cat(simID + ": LOST - RESTARTING\n");
+			
+			sim.readFromPopulationFile("/tmp/slim_" + simID + ".trees");
+			setSeed(rdunif(1, 0, asInteger(2^62) - 1));
+		}
+	}
+}

--- a/tests/recipes/Recipe 17.4 - Detecting the "dip in diversity" (analyzing tree heights in Python) I.txt
+++ b/tests/recipes/Recipe 17.4 - Detecting the "dip in diversity" (analyzing tree heights in Python) I.txt
@@ -1,0 +1,26 @@
+// Keywords: tree-sequence recording, tree sequence recording
+
+initialize() {
+	defineConstant("N", 100);  // pop size
+	defineConstant("L", 1e8);    // total chromosome length
+	defineConstant("L0", 200e3); // between genes
+	defineConstant("L1", 1e3);   // gene length
+	initializeTreeSeq();
+	initializeMutationRate(1e-7);
+	initializeRecombinationRate(1e-8, L-1);
+	initializeMutationType("m2", 0.5, "g", -(5/N), 1.0);
+	initializeGenomicElementType("g2", m2, 1.0);
+	
+	for (start in seq(from=L0, to=L-(L0+L1), by=(L0+L1)))
+		initializeGenomicElement(g2, start, (start+L1)-1);
+}
+1 {
+	sim.addSubpop("p1", N);
+	sim.rescheduleScriptBlock(s1, 10*N, 10*N);
+}
+s1 10 late() {
+	sim.treeSeqOutput("./recipe_17.4.trees");
+}
+
+// Part II of this recipe, which is a Python script, may be found in
+// the Recipes archive downloadable at https://messerlab.org/slim/

--- a/tests/recipes/Recipe 17.4 - Detecting the "dip in diversity" (analyzing tree heights in Python) II.py
+++ b/tests/recipes/Recipe 17.4 - Detecting the "dip in diversity" (analyzing tree heights in Python) II.py
@@ -1,0 +1,37 @@
+# Keywords: Python, tree-sequence recording, tree sequence recording
+
+# This is a Python recipe; note that it runs the SLiM model internally, below
+
+import subprocess, msprime, pyslim
+import matplotlib.pyplot as plt
+import numpy as np
+
+# Run the SLiM model and load the resulting .trees
+# subprocess.check_output(["slim", "-m", "-s", "0", "./recipe_17.4.slim"])
+ts = pyslim.load("./recipe_17.4.trees").simplify()
+
+# Measure the tree height at each base position
+height_for_pos = np.zeros(int(ts.sequence_length))
+for tree in ts.trees():
+    mean_height = np.mean([tree.time(root) for root in tree.roots])
+    left, right = map(int, tree.interval)
+    height_for_pos[left: right] = mean_height
+
+# Convert heights along chromosome into heights at distances from gene
+height_for_pos = height_for_pos - np.min(height_for_pos)
+L, L0, L1 = int(1e8), int(200e3), int(1e3)   # total length, length between genes, gene length
+gene_starts = np.arange(L0, L - (L0 + L1) + 1, L0 + L1)
+gene_ends = gene_starts + L1 - 1
+max_d = L0 // 4
+height_for_left_dist = np.zeros(max_d)
+height_for_right_dist = np.zeros(max_d)
+for d in range(max_d):
+    height_for_left_dist[d] = np.mean(height_for_pos[gene_starts - d - 1])
+    height_for_right_dist[d] = np.mean(height_for_pos[gene_ends + d + 1])
+height_for_distance = np.hstack([height_for_left_dist[::-1], height_for_right_dist])
+distances = np.hstack([np.arange(-max_d, 0), np.arange(1, max_d + 1)])
+
+# Make a simple plot
+plt.plot(distances, height_for_distance)
+# plt.show()
+plt.savefig("recipe_17.4.png")

--- a/tests/recipes/Recipe 17.5 - Mapping admixture (analyzing ancestry in Python) I.txt
+++ b/tests/recipes/Recipe 17.5 - Mapping admixture (analyzing ancestry in Python) I.txt
@@ -1,0 +1,40 @@
+// Keywords: tree-sequence recording, tree sequence recording, migration, dispersal
+
+initialize() {
+	defineConstant("L", 1e8);
+	initializeTreeSeq();
+	initializeMutationRate(0);
+	initializeMutationType("m1", 0.5, "f", 0.1);
+	initializeGenomicElementType("g1", m1, 1.0);
+	initializeGenomicElement(g1, 0, L-1);
+	initializeRecombinationRate(1e-8);
+}
+1 late() {
+	sim.addSubpop("p1", 500);
+	sim.addSubpop("p2", 500);
+	sim.treeSeqRememberIndividuals(sim.subpopulations.individuals);
+	
+	p1.genomes.addNewDrawnMutation(m1, asInteger(L * 0.2));
+	p2.genomes.addNewDrawnMutation(m1, asInteger(L * 0.8));
+	
+	sim.addSubpop("p3", 1000);
+	p3.setMigrationRates(c(p1, p2), c(0.5, 0.5));
+}
+2 late() {
+	p3.setMigrationRates(c(p1, p2), c(0.0, 0.0));
+	p1.setSubpopulationSize(0);
+	p2.setSubpopulationSize(0);
+}
+2: late() {
+	if (sim.mutationsOfType(m1).size() == 0)
+	{
+		sim.treeSeqOutput("./recipe_17.5.trees");
+		sim.simulationFinished();
+	}
+}
+10000 late() {
+	stop("Did not reach fixation of beneficial alleles.");
+}
+
+// Part II of this recipe, which is a Python script, may be found in
+// the Recipes archive downloadable at https://messerlab.org/slim/

--- a/tests/recipes/Recipe 17.5 - Mapping admixture (analyzing ancestry in Python) II.py
+++ b/tests/recipes/Recipe 17.5 - Mapping admixture (analyzing ancestry in Python) II.py
@@ -1,0 +1,30 @@
+# Keywords: Python, tree-sequence recording, tree sequence recording
+
+# This is a Python recipe; note that it runs the SLiM model internally, below
+
+import subprocess, msprime, pyslim
+import matplotlib.pyplot as plt
+import numpy as np
+
+# Run the SLiM model and load the resulting .trees file
+#subprocess.check_output(["slim", "-m", "-s", "0", "./recipe_17.5.slim"])
+ts = pyslim.load("./recipe_17.5.trees")
+
+# Load the .trees file and assess true local ancestry
+breaks = np.zeros(ts.num_trees + 1)
+ancestry = np.zeros(ts.num_trees + 1)
+for tree in ts.trees():
+    subpop_sum, subpop_weights = 0, 0
+    for root in tree.roots:
+        leaves_count = tree.num_samples(root) - 1  # subtract one for the root, which is a sample
+        subpop_sum += tree.population(root) * leaves_count
+        subpop_weights += leaves_count
+    breaks[tree.index] = tree.interval[0]
+    ancestry[tree.index] = subpop_sum / subpop_weights
+breaks[-1] = ts.sequence_length
+ancestry[-1] = ancestry[-2]
+
+# Make a simple plot
+plt.plot(breaks, ancestry)
+# plt.show()
+plt.savefig("./recipe_17.5.png")

--- a/tests/recipes/Recipe 17.7 - Analyzing selection coefficients in Python with pyslim I.txt
+++ b/tests/recipes/Recipe 17.7 - Analyzing selection coefficients in Python with pyslim I.txt
@@ -1,0 +1,18 @@
+// Keywords: tree-sequence recording, tree sequence recording
+
+initialize() {
+	initializeTreeSeq();
+	initializeMutationRate(1e-10);
+	initializeMutationType("m1", 0.5, "g", 0.1, 0.1);
+	initializeMutationType("m2", 0.5, "g", -0.1, 0.1);
+	initializeGenomicElementType("g1", c(m1, m2), c(1.0, 1.0));
+	initializeGenomicElement(g1, 0, 1e8-1);
+	initializeRecombinationRate(1e-8);
+}
+1 {
+	sim.addSubpop("p1", 500);
+}
+20000 late() { sim.treeSeqOutput("./recipe_17.7.trees"); }
+
+// Part II of this recipe, which is a Python script, may be found in
+// the Recipes archive downloadable at https://messerlab.org/slim/

--- a/tests/recipes/Recipe 17.7 - Analyzing selection coefficients in Python with pyslim II.py
+++ b/tests/recipes/Recipe 17.7 - Analyzing selection coefficients in Python with pyslim II.py
@@ -1,0 +1,19 @@
+# Keywords: Python, tree-sequence recording, tree sequence recording
+
+import msprime, pyslim
+
+ts = pyslim.load("recipe_17.7.trees")
+
+# selection coefficients of all selected mutations
+coeffs = []
+for mut in ts.mutations():
+    md = mut.metadata
+    sel = [x["selection_coeff"] for x in md["mutation_list"]]
+    if any([s != 0 for s in sel]):
+        coeffs += sel
+
+b = [x for x in coeffs if x > 0]
+d = [x for x in coeffs if x < 0]
+
+print("Beneficial: " + str(len(b)) + ", mean " + str(sum(b) / len(b)))
+print("Deleterious: " + str(len(d)) + ", mean " + str(sum(d) / len(d)))

--- a/tests/recipes/Recipe 17.8 - Starting a hermaphroditic WF model with a coalescent history I.py
+++ b/tests/recipes/Recipe 17.8 - Starting a hermaphroditic WF model with a coalescent history I.py
@@ -1,0 +1,8 @@
+# Keywords: Python, tree-sequence recording, tree sequence recording
+
+import msprime, pyslim
+
+ts = msprime.simulate(sample_size=10000, Ne=5000, length=1e8,
+    mutation_rate=0.0, recombination_rate=1e-8)
+slim_ts = pyslim.annotate_defaults(ts, model_type="WF", slim_generation=1)
+slim_ts.dump("recipe_17.8.trees")

--- a/tests/recipes/Recipe 17.8 - Starting a hermaphroditic WF model with a coalescent history II.txt
+++ b/tests/recipes/Recipe 17.8 - Starting a hermaphroditic WF model with a coalescent history II.txt
@@ -1,0 +1,30 @@
+// Keywords: tree-sequence recording, tree sequence recording
+
+// Part I of this recipe, which is a Python script, may be found in
+// the Recipes archive downloadable at https://messerlab.org/slim/
+
+initialize() {
+	initializeTreeSeq();
+	initializeMutationRate(0);
+	initializeMutationType("m1", 0.5, "f", 0.0);
+	initializeMutationType("m2", 0.5, "f", 0.1);
+	initializeGenomicElementType("g1", m2, 1.0);
+	initializeGenomicElement(g1, 0, 1e8-1);
+	initializeRecombinationRate(1e-8);
+}
+1 late() {
+	sim.readFromPopulationFile("recipe_17.8.trees");
+	target = sample(sim.subpopulations.genomes, 1);
+	target.addNewDrawnMutation(m2, 10000);
+}
+1: late() {
+	if (sim.mutationsOfType(m2).size() == 0) {
+		print(sim.substitutions.size() ? "FIXED" else "LOST");
+		sim.treeSeqOutput("recipe_17.8_II.trees");
+		sim.simulationFinished();
+	}
+}
+2000 { sim.simulationFinished(); }
+
+// Part III of this recipe, which is a Python script, may be found in
+// the Recipes archive downloadable at https://messerlab.org/slim/

--- a/tests/recipes/Recipe 17.8 - Starting a hermaphroditic WF model with a coalescent history III.py
+++ b/tests/recipes/Recipe 17.8 - Starting a hermaphroditic WF model with a coalescent history III.py
@@ -1,0 +1,9 @@
+# Keywords: Python, tree-sequence recording, tree sequence recording
+
+import msprime, pyslim
+
+ts = pyslim.load("recipe_17.8_II.trees").simplify()
+
+for tree in ts.trees():
+    for root in tree.roots:
+        print(tree.time(root))

--- a/tests/recipes/Recipe 17.9 - Starting a sexual nonWF model with a coalescent history I.py
+++ b/tests/recipes/Recipe 17.9 - Starting a sexual nonWF model with a coalescent history I.py
@@ -1,0 +1,47 @@
+# Keywords: Python, nonWF, non-Wright-Fisher, tree-sequence recording, tree sequence recording
+
+import msprime, pyslim, random
+import numpy as np
+
+ts = msprime.simulate(sample_size=10000, Ne=5000, length=1e8,
+    mutation_rate=0.0, recombination_rate=1e-8)
+
+tables = ts.dump_tables()
+pyslim.annotate_defaults_tables(tables, model_type="nonWF", slim_generation=1)
+
+# add sexes and ages
+individual_metadata = [ind.metadata for ind in tables.individuals]
+for md in individual_metadata:
+    md["sex"] = random.choice([pyslim.INDIVIDUAL_TYPE_FEMALE, pyslim.INDIVIDUAL_TYPE_MALE])
+    md["age"] = random.choice([0, 1, 2, 3, 4])
+
+ims = tables.individuals.metadata_schema
+tables.individuals.packset_metadata(
+        [ims.validate_and_encode_row(md) for md in individual_metadata])
+
+# add selected mutation
+
+mut_ind_id = random.choice(range(tables.individuals.num_rows))
+mut_node_id = random.choice(np.where(tables.nodes.individual == mut_ind_id)[0])
+mut_node = tables.nodes[mut_node_id]
+mut_metadata = {
+        "mutation_list": [
+            {
+              "mutation_type": 2,
+              "selection_coeff": 0.1,
+              "subpopulation": mut_node.population,
+              "slim_time": int(tables.metadata['SLiM']['generation'] - mut_node.time),
+              "nucleotide": -1
+            }
+        ]
+    }
+site_num = tables.sites.add_row(position=5000, ancestral_state='')
+tables.mutations.add_row(
+        node=mut_node_id,
+        site=site_num,
+        derived_state='1',
+        time=mut_node.time,
+        metadata=mut_metadata)
+
+slim_ts = pyslim.load_tables(tables)
+slim_ts.dump("recipe_17.9.trees")

--- a/tests/recipes/Recipe 17.9 - Starting a sexual nonWF model with a coalescent history II.txt
+++ b/tests/recipes/Recipe 17.9 - Starting a sexual nonWF model with a coalescent history II.txt
@@ -1,0 +1,34 @@
+// Keywords: nonWF, non-Wright-Fisher, sexual, tree-sequence recording, tree sequence recording, reproduction()
+
+// Part I of this recipe, which is a Python script, may be found in
+// the Recipes archive downloadable at https://messerlab.org/slim/
+
+initialize() {
+	initializeSLiMModelType("nonWF");
+	initializeTreeSeq();
+	initializeSex("A");
+	initializeMutationRate(0);
+	initializeMutationType("m1", 0.5, "f", 0.0);
+	initializeMutationType("m2", 0.5, "f", 0.1);
+	m2.convertToSubstitution=T;
+	initializeGenomicElementType("g1", m2, 1.0);
+	initializeGenomicElement(g1, 0, 1e8-1);
+	initializeRecombinationRate(1e-8);
+}
+reproduction(NULL, "F") {
+	subpop.addCrossed(individual, subpop.sampleIndividuals(1, sex="M"));
+}
+1 early() {
+	sim.readFromPopulationFile("recipe_17.9.trees");
+}
+early() {
+	p0.fitnessScaling = 5000 / p0.individualCount;
+}
+1: late() {
+	if (sim.mutationsOfType(m2).size() == 0) {
+		print(sim.substitutions.size() ? "FIXED" else "LOST");
+		sim.treeSeqOutput("recipe_17.9_II.trees");
+		sim.simulationFinished();
+	}
+}
+2000 { sim.simulationFinished(); }

--- a/tests/recipes/Recipe 18.13 - Tree-sequence recording and nucleotide-based models I.txt
+++ b/tests/recipes/Recipe 18.13 - Tree-sequence recording and nucleotide-based models I.txt
@@ -1,0 +1,14 @@
+// Keywords: nucleotide-based, nucleotide sequence, sequence-based mutation rate
+
+initialize() {
+	defineConstant("L", 1e5);
+	initializeSLiMOptions(nucleotideBased=T);
+	initializeTreeSeq();
+	initializeAncestralNucleotides(randomNucleotides(L));
+	initializeMutationTypeNuc("m1", 0.5, "f", 0.0);
+	initializeGenomicElementType("g1", m1, 1.0, mmJukesCantor(1e-6));
+	initializeGenomicElement(g1, 0, L-1);
+	initializeRecombinationRate(1e-6);
+}
+1 { sim.addSubpop("p1", 1000); }
+1000 { sim.treeSeqOutput("recipe_nucleotides.trees"); }

--- a/tests/recipes/Recipe 18.13 - Tree-sequence recording and nucleotide-based models II.py
+++ b/tests/recipes/Recipe 18.13 - Tree-sequence recording and nucleotide-based models II.py
@@ -1,0 +1,25 @@
+# Keywords: Python, nucleotide-based, nucleotide sequence, sequence-based mutation rate
+
+import pyslim
+import numpy as np
+
+ts = pyslim.load("recipe_nucleotides.trees")
+
+M = [[0 for _ in pyslim.NUCLEOTIDES] for _ in pyslim.NUCLEOTIDES]
+for mut in ts.mutations():
+    mut_list = mut.metadata["mutation_list"]
+    k = np.argmax([u["slim_time"] for u in mut_list])
+    derived_nuc = mut_list[k]["nucleotide"]
+    if mut.parent == -1:
+        acgt = ts.reference_sequence[int(mut.position)]
+        parent_nuc = pyslim.NUCLEOTIDES.index(acgt)
+    else:
+        parent_mut = ts.mutation(mut.parent)
+        assert(parent_mut.site == mut.site)
+        parent_nuc = parent_mut.metadata["mutation_list"][0]["nucleotide"]
+    M[parent_nuc][derived_nuc] += 1
+
+print("{}\t{}\t{}".format('ancestral', 'derived', 'count'))
+for j, a in enumerate(pyslim.NUCLEOTIDES):
+    for k, b in enumerate(pyslim.NUCLEOTIDES):
+        print("{}\t{}\t{}".format(a, b, M[j][k]))

--- a/tests/recipes/Recipe 18.13 - Tree-sequence recording and nucleotide-based models III.py
+++ b/tests/recipes/Recipe 18.13 - Tree-sequence recording and nucleotide-based models III.py
@@ -1,0 +1,36 @@
+# Keywords: Python, nucleotide-based, nucleotide sequence, sequence-based mutation rate
+
+import pyslim
+import numpy as np
+
+ts = pyslim.load("recipe_nucleotides.trees")
+slim_gen = ts.metadata["SLiM"]["generation"]
+
+M = np.zeros((4,4,4,4), dtype='int')
+for mut in ts.mutations():
+    pos = ts.site(mut.site).position 
+    # skip mutations at the end of the sequence
+    if pos > 0 and pos < ts.sequence_length - 1:
+        mut_list = mut.metadata["mutation_list"]
+        k = np.argmax([u["slim_time"] for u in mut_list])
+        derived_nuc = mut_list[k]["nucleotide"]
+        left_nuc = ts.nucleotide_at(mut.node, pos - 1, 
+                time = slim_gen - mut_list[k]["slim_time"] - 1.0)
+        right_nuc = ts.nucleotide_at(mut.node, pos + 1,
+                time = slim_gen - mut_list[k]["slim_time"] - 1.0)
+        if mut.parent == -1:
+            acgt = ts.reference_sequence[int(mut.position)]
+            parent_nuc = pyslim.NUCLEOTIDES.index(acgt)
+        else:
+            parent_mut = ts.mutation(mut.parent)
+            assert(parent_mut.site == mut.site)
+            parent_nuc = parent_mut.metadata["mutation_list"][0]["nucleotide"]
+        M[left_nuc, parent_nuc, right_nuc, derived_nuc] += 1
+
+print("{}\t{}\t{}".format('ancestral', 'derived', 'count'))
+for j0, a0 in enumerate(pyslim.NUCLEOTIDES):
+    for j1, a1 in enumerate(pyslim.NUCLEOTIDES):
+        for j2, a2 in enumerate(pyslim.NUCLEOTIDES):
+            for k, b in enumerate(pyslim.NUCLEOTIDES):
+                print("{}{}{}\t{}{}{}\t{}".format(a0, a1, a2, a0, b, a2,
+                        M[j0, j1, j2, k]))

--- a/tests/recipes/check_trees.py
+++ b/tests/recipes/check_trees.py
@@ -1,0 +1,10 @@
+#!/usr/bin/env python3
+
+import sys
+import pyslim
+
+treefile = sys.argv[1] 
+
+ts = pyslim.load(treefile)
+print(f"The file '{treefile}' has {ts.num_trees} trees relating {ts.num_individuals} individuals "
+      f"with {ts.num_mutations} mutations at {ts.num_sites} sites.")

--- a/tests/test_legacy_metadata.py
+++ b/tests/test_legacy_metadata.py
@@ -4,15 +4,16 @@ Test cases for the deprecated, legacy metadata representation of pyslim.
 from __future__ import print_function
 from __future__ import division
 
-import pyslim
-import msprime
-import tskit
-import tests
 import unittest
 import os
 import tempfile
 import numpy as np
+import msprime
+import tskit
 
+import pyslim
+
+import tests
 
 class LegacyPyslimTestCase(tests.PyslimTestCase):
 

--- a/tests/test_legacy_metadata.py
+++ b/tests/test_legacy_metadata.py
@@ -1,0 +1,360 @@
+"""
+Test cases for the deprecated, legacy metadata representation of pyslim.
+"""
+from __future__ import print_function
+from __future__ import division
+
+import pyslim
+import msprime
+import tskit
+import tests
+import unittest
+import os
+import tempfile
+import numpy as np
+
+
+class LegacyPyslimTestCase(tests.PyslimTestCase):
+
+    def get_slim_examples(self, return_info=False, **kwargs):
+        examples = super().get_slim_examples(return_info=return_info, **kwargs)
+        if return_info:
+            for ts, ex in examples:
+                ts.legacy_metadata = True
+                yield ts, ex
+        else:
+            for ts in examples:
+                ts.legacy_metadata = True
+                yield ts
+
+
+class TestEncodeDecode(LegacyPyslimTestCase):
+    '''
+    Tests for conversion to/from binary representations of metadata.
+    '''
+
+    def test_decode_errors(self):
+        with self.assertRaises(ValueError):
+            pyslim.decode_mutation(2.0)
+        with self.assertRaises(ValueError):
+            pyslim.decode_mutation([2.0, 3.0])
+        with self.assertRaises(ValueError):
+            pyslim.decode_node(2.0)
+        with self.assertRaises(ValueError):
+            pyslim.decode_node([1, 2])
+        with self.assertRaises(ValueError):
+            pyslim.decode_individual(3.0)
+        with self.assertRaises(ValueError):
+            pyslim.decode_individual([1, 2])
+        with self.assertRaises(ValueError):
+            pyslim.decode_population(1.0)
+        with self.assertRaises(ValueError):
+            pyslim.decode_population([2, 3])
+
+    def test_decode_already_mutation(self):
+        m = [pyslim.MutationMetadata(mutation_type = 0,
+                                     selection_coeff = 0.2,
+                                     population = k,
+                                     slim_time = 130,
+                                     nucleotide = 2) for k in range(4)]
+        with self.assertWarns(DeprecationWarning):
+            dm = pyslim.decode_mutation(m)
+        self.assertEqual(type(dm), type([]))
+        for a, b in zip(m, dm):
+            self.assertEqual(a, b)
+
+    def test_decode_already_node(self):
+        m = pyslim.NodeMetadata(slim_id=123, is_null=True, genome_type=0)
+        with self.assertWarns(DeprecationWarning):
+            dm = pyslim.decode_node(m)
+        self.assertEqual(m, dm)
+
+    def test_decode_already_population(self):
+        m = pyslim.PopulationMetadata(slim_id=1, selfing_fraction=0.2,
+                                      female_cloning_fraction=0.3,
+                                      male_cloning_fraction=0.4,
+                                      sex_ratio=0.5, bounds_x0=0, bounds_x1=10,
+                                      bounds_y0=2, bounds_y1=20, bounds_z0=3,
+                                      bounds_z1=30, migration_records=[])
+        with self.assertWarns(DeprecationWarning):
+            dm = pyslim.decode_population(m)
+        self.assertEqual(m, dm)
+
+    def test_decode_already_individual(self):
+        m = pyslim.IndividualMetadata(pedigree_id=24, age=8, population=1,
+                                      sex=1, flags=0)
+        with self.assertWarns(DeprecationWarning):
+            dm = pyslim.decode_individual(m)
+        self.assertEqual(m, dm)
+
+    def test_mutation_metadata(self):
+        for md_length in [0, 1, 5]:
+            md = [pyslim.MutationMetadata(
+                     mutation_type=j, selection_coeff=0.5, population=j,
+                     slim_time=10 + j, nucleotide=(j % 5) - 1) 
+                     for j in range(md_length)]
+            with self.assertWarns(DeprecationWarning):
+                md_bytes = pyslim.encode_mutation(md)
+            with self.assertWarns(DeprecationWarning):
+                new_md = pyslim.decode_mutation(md_bytes)
+            self.assertEqual(len(md), len(new_md))
+            for x, y in zip(md, new_md):
+                self.assertEqual(x, y)
+
+    def test_node_metadata(self):
+        md = pyslim.NodeMetadata(slim_id=2, is_null=False,
+                                 genome_type=pyslim.GENOME_TYPE_X)
+        with self.assertWarns(DeprecationWarning):
+            md_bytes = pyslim.encode_node(md)
+        with self.assertWarns(DeprecationWarning):
+            new_md = pyslim.decode_node(md_bytes)
+        self.assertEqual(md, new_md)
+
+    def test_individual_metadata(self):
+        md = pyslim.IndividualMetadata(
+                age=2, pedigree_id=23, population=0,
+                sex=pyslim.INDIVIDUAL_TYPE_MALE,
+                flags=pyslim.INDIVIDUAL_FLAG_MIGRATED)
+        with self.assertWarns(DeprecationWarning):
+            md_bytes = pyslim.encode_individual(md)
+        with self.assertWarns(DeprecationWarning):
+            new_md = pyslim.decode_individual(md_bytes)
+        self.assertEqual(md, new_md)
+
+    def test_population_metadata(self):
+        mrs = [pyslim.PopulationMigrationMetadata(source_subpop=j, migration_rate=0.2)
+               for j in range(3)]
+        for mr_list in [[], mrs]:
+            md = pyslim.PopulationMetadata(
+                    slim_id=1, selfing_fraction=0.75, female_cloning_fraction=0.2,
+                    male_cloning_fraction=0.8, sex_ratio=0.6, bounds_x0=-1.0,
+                    bounds_x1=2.0, bounds_y0=0.0, bounds_y1=0.0, bounds_z0=0.0,
+                    bounds_z1=1.0, migration_records=mr_list)
+            with self.assertWarns(DeprecationWarning):
+                md_bytes = pyslim.encode_population(md)
+            with self.assertWarns(DeprecationWarning):
+                new_md = pyslim.decode_population(md_bytes)
+            self.assertEqual(md, new_md)
+
+
+class TestAnnotate(LegacyPyslimTestCase):
+    '''
+    Tests the table annotation methods.
+    '''
+
+    def test_annotate_mutations(self):
+        for ts in self.get_slim_examples():
+            tables = ts.tables
+            new_tables = ts.tables
+            metadata = []
+            for md in tskit.unpack_bytes(tables.mutations.metadata,
+                                         tables.mutations.metadata_offset):
+                with self.assertWarns(DeprecationWarning):
+                    dm = pyslim.decode_mutation(md)
+                with self.assertWarns(DeprecationWarning):
+                    edm = pyslim.encode_mutation(dm)
+                self.assertEqual(md, edm)
+                metadata.append(dm)
+
+            with self.assertWarns(DeprecationWarning):
+                pyslim.annotate_mutation_metadata(new_tables, metadata)
+            self.assertTableCollectionsEqual(tables, new_tables)
+
+    def test_annotate_nodes(self):
+        for ts in self.get_slim_examples():
+            tables = ts.tables
+            new_tables = ts.tables
+            metadata = []
+            for md in tskit.unpack_bytes(tables.nodes.metadata,
+                                           tables.nodes.metadata_offset):
+                with self.assertWarns(DeprecationWarning):
+                    dm = pyslim.decode_node(md)
+                with self.assertWarns(DeprecationWarning):
+                    edm = pyslim.encode_node(dm)
+                self.assertEqual(md, edm)
+                metadata.append(dm)
+
+            with self.assertWarns(DeprecationWarning):
+                pyslim.annotate_node_metadata(new_tables, metadata)
+            self.assertTableCollectionsEqual(tables, new_tables)
+
+    def test_annotate_individuals(self):
+        for ts in self.get_slim_examples():
+            tables = ts.tables
+            new_tables = ts.tables
+            metadata = []
+            for md in tskit.unpack_bytes(tables.individuals.metadata,
+                                           tables.individuals.metadata_offset):
+                with self.assertWarns(DeprecationWarning):
+                    dm = pyslim.decode_individual(md)
+                with self.assertWarns(DeprecationWarning):
+                    edm = pyslim.encode_individual(dm)
+                self.assertEqual(md, edm)
+                metadata.append(dm)
+
+            with self.assertWarns(DeprecationWarning):
+                pyslim.annotate_individual_metadata(new_tables, metadata)
+            self.assertTableCollectionsEqual(tables, new_tables)
+
+    def test_annotate_populations(self):
+        for ts in self.get_slim_examples():
+            tables = ts.tables
+            new_tables = ts.tables
+            metadata = []
+            for md in tskit.unpack_bytes(tables.populations.metadata,
+                                         tables.populations.metadata_offset):
+                with self.assertWarns(DeprecationWarning):
+                    dm = pyslim.decode_population(md)
+                with self.assertWarns(DeprecationWarning):
+                    edm = pyslim.encode_population(dm)
+                self.assertEqual(md, edm)
+                metadata.append(dm)
+
+            with self.assertWarns(DeprecationWarning):
+                pyslim.annotate_population_metadata(new_tables, metadata)
+            self.assertTableCollectionsEqual(tables, new_tables)
+
+
+class TestDumpLoad(LegacyPyslimTestCase):
+    '''
+    Test reading and writing.
+    '''
+
+    def setUp(self):
+        fd, self.temp_file = tempfile.mkstemp(prefix="pyslim_ts_")
+        os.close(fd)
+
+    def tearDown(self):
+        os.unlink(self.temp_file)
+
+    def verify_times(self, ts, slim_ts):
+        gen = slim_ts.slim_generation
+        self.assertEqual(ts.num_nodes, slim_ts.num_nodes)
+        # verify internal consistency
+        for j in range(slim_ts.num_nodes):
+            self.assertEqual(slim_ts.node(j).time,
+                             slim_ts.tables.nodes.time[j])
+        # verify consistency between tree sequences
+        for n1, n2 in zip(ts.nodes(), slim_ts.nodes()):
+            self.assertEqual(n1.time, n2.time)
+
+    def verify_dump_equality(self, ts):
+        """
+        Verifies that we can dump a copy of the specified tree sequence
+        to the specified file, and load an identical copy.
+        """
+        ts.dump(self.temp_file)
+        ts2 = pyslim.load(self.temp_file, legacy_metadata=True)
+        self.assertEqual(ts.num_samples, ts2.num_samples)
+        self.assertEqual(ts.sequence_length, ts2.sequence_length)
+        self.assertEqual(ts.tables, ts2.tables)
+        self.assertEqual(ts.reference_sequence, ts2.reference_sequence)
+
+    def test_load_tables(self):
+        for ts in self.get_slim_examples():
+            self.assertTrue(type(ts) is pyslim.SlimTreeSequence)
+            tables = ts.tables
+            new_ts = pyslim.load_tables(tables, legacy_metadata=True)
+            self.assertTrue(type(new_ts) is pyslim.SlimTreeSequence)
+            new_tables = new_ts.tables
+            self.assertEqual(tables, new_tables)
+
+    def test_load(self):
+        for _, ex in self.get_slim_examples(return_info=True):
+            fn = ex['basename'] + ".trees"
+            # load in msprime then switch
+            msp_ts = tskit.load(fn)
+            self.assertTrue(type(msp_ts) is msprime.TreeSequence)
+            # transfer tables
+            msp_tables = msp_ts.tables
+            new_ts = pyslim.load_tables(msp_tables, legacy_metadata=True)
+            self.assertTrue(isinstance(new_ts, pyslim.SlimTreeSequence))
+            self.verify_times(msp_ts, new_ts)
+            new_tables = new_ts.tables
+            self.assertTableCollectionsEqual(msp_tables, new_tables)
+            # convert directly
+            new_ts = pyslim.SlimTreeSequence(msp_ts)
+            self.assertTrue(type(new_ts) is pyslim.SlimTreeSequence)
+            self.verify_times(msp_ts, new_ts)
+            new_tables = new_ts.tables
+            self.assertTableCollectionsEqual(msp_tables, new_tables)
+            # load to pyslim from file
+            slim_ts = pyslim.load(fn, legacy_metadata=True)
+            self.assertTrue(type(slim_ts) is pyslim.SlimTreeSequence)
+            slim_tables = slim_ts.tables
+            self.assertTableCollectionsEqual(msp_tables, slim_tables)
+            self.assertEqual(slim_ts.slim_generation, new_ts.slim_generation)
+
+    def test_dump_equality(self):
+        for ts in self.get_slim_examples():
+            self.verify_dump_equality(ts)
+
+
+class TestIndividualMetadata(LegacyPyslimTestCase):
+    # Tests for extra stuff related to Individuals.
+
+    def test_individual_derived_info(self):
+        for ts in self.get_slim_examples():
+            for j, ind in enumerate(ts.individuals()):
+                a = ts.tables.individuals.metadata_offset[j]
+                b = ts.tables.individuals.metadata_offset[j+1]
+                raw_md = ts.tables.individuals.metadata[a:b]
+                with self.assertWarns(DeprecationWarning):
+                    md = pyslim.decode_individual(raw_md)
+                self.assertEqual(ind.metadata, md)
+                self.assertEqual(ts.individual(j).metadata, md)
+                for n in ind.nodes:
+                    self.assertEqual(ts.node(n).population, ind.population)
+                    self.assertEqual(ts.node(n).time, ind.time)
+
+
+class TestNodeMetadata(LegacyPyslimTestCase):
+    '''
+    Tests for extra stuff related to Nodes.
+    '''
+
+    def test_node_derived_info(self):
+        for ts in self.get_slim_examples():
+            for j, node in enumerate(ts.nodes()):
+                a = ts.tables.nodes.metadata_offset[j]
+                b = ts.tables.nodes.metadata_offset[j+1]
+                raw_md = ts.tables.nodes.metadata[a:b]
+                with self.assertWarns(DeprecationWarning):
+                    md = pyslim.decode_node(raw_md)
+                self.assertEqual(node.metadata, md)
+                self.assertEqual(ts.node(j).metadata, md)
+
+
+class TestMutationMetadata(LegacyPyslimTestCase):
+    '''
+    Tests for extra stuff related to Mutations.
+    '''
+
+    def test_mutation_derived_info(self):
+        for ts in self.get_slim_examples():
+            for j, mut in enumerate(ts.mutations()):
+                a = ts.tables.mutations.metadata_offset[j]
+                b = ts.tables.mutations.metadata_offset[j+1]
+                raw_md = ts.tables.mutations.metadata[a:b]
+                with self.assertWarns(DeprecationWarning):
+                    md = pyslim.decode_mutation(raw_md)
+                self.assertEqual(mut.metadata, md)
+                self.assertEqual(ts.mutation(j).metadata, md)
+
+
+class TestPopulationMetadata(LegacyPyslimTestCase):
+    '''
+    Tests for extra stuff related to Populations.
+    '''
+
+    def test_population_derived_info(self):
+        for ts in self.get_slim_examples():
+            for j, pop in enumerate(ts.populations()):
+                a = ts.tables.populations.metadata_offset[j]
+                b = ts.tables.populations.metadata_offset[j+1]
+                raw_md = ts.tables.populations.metadata[a:b]
+                with self.assertWarns(DeprecationWarning):
+                    md = pyslim.decode_population(raw_md)
+                self.assertEqual(pop.metadata, md)
+                self.assertEqual(ts.population(j).metadata, md)
+

--- a/tests/test_metadata.py
+++ b/tests/test_metadata.py
@@ -13,7 +13,28 @@ import os
 import tempfile
 import numpy as np
 
+
 class TestMetadataSchemas(tests.PyslimTestCase):
+
+    def validate_table_metadata(self, table):
+        ms = table.metadata_schema
+        for j, row in enumerate(table):
+            a = table.metadata_offset[j]
+            b = table.metadata_offset[j+1]
+            raw_md = table.metadata[a:b]
+            # this checks to make sure metadata follows the schema
+            enc_md = ms.validate_and_encode_row(row.metadata)
+            self.assertEqual(bytes(raw_md), enc_md)
+
+    def validate_metadata(self, ts):
+        tables = ts.tables
+        for t in (tables.populations, tables.individuals, tables.nodes, tables.edges,
+                  tables.sites, tables.mutations, tables.migrations):
+            self.validate_table_metadata(t)
+
+    def test_slim_metadata(self):
+        for ts in self.get_slim_examples():
+            self.validate_metadata(ts)
 
     def test_default_metadata(self):
         for k in pyslim.slim_metadata_schemas:
@@ -48,7 +69,7 @@ class TestMetadataSchemas(tests.PyslimTestCase):
             self.assertEqual(
                     t.populations.metadata_schema,
                     pyslim.slim_metadata_schemas['population'])
-            break
+
 
 class TestTreeSequenceMetadata(tests.PyslimTestCase):
 
@@ -131,176 +152,13 @@ class TestTreeSequenceMetadata(tests.PyslimTestCase):
             self.assertEqual(new_ts.metadata, ts.metadata)
 
 
-class TestEncodeDecode(tests.PyslimTestCase):
-    '''
-    Tests for conversion to/from binary representations of metadata.
-    '''
-
-    def test_decode_errors(self):
-        with self.assertRaises(ValueError):
-            pyslim.decode_mutation(2.0)
-        with self.assertRaises(ValueError):
-            pyslim.decode_mutation([2.0, 3.0])
-        with self.assertRaises(ValueError):
-            pyslim.decode_node(2.0)
-        with self.assertRaises(ValueError):
-            pyslim.decode_node([1, 2])
-        with self.assertRaises(ValueError):
-            pyslim.decode_individual(3.0)
-        with self.assertRaises(ValueError):
-            pyslim.decode_individual([1, 2])
-        with self.assertRaises(ValueError):
-            pyslim.decode_population(1.0)
-        with self.assertRaises(ValueError):
-            pyslim.decode_population([2, 3])
-
-    def test_decode_already_mutation(self):
-        m = [pyslim.MutationMetadata(mutation_type = 0,
-                                     selection_coeff = 0.2,
-                                     population = k,
-                                     slim_time = 130,
-                                     nucleotide = 2) for k in range(4)]
-        dm = pyslim.decode_mutation(m)
-        self.assertEqual(type(dm), type([]))
-        for a, b in zip(m, dm):
-            self.assertEqual(a, b)
-
-    def test_decode_already_node(self):
-        m = pyslim.NodeMetadata(slim_id=123, is_null=True, genome_type=0)
-        dm = pyslim.decode_node(m)
-        self.assertEqual(m, dm)
-
-    def test_decode_already_population(self):
-        m = pyslim.PopulationMetadata(slim_id=1, selfing_fraction=0.2,
-                                      female_cloning_fraction=0.3,
-                                      male_cloning_fraction=0.4,
-                                      sex_ratio=0.5, bounds_x0=0, bounds_x1=10,
-                                      bounds_y0=2, bounds_y1=20, bounds_z0=3,
-                                      bounds_z1=30, migration_records=[])
-        dm = pyslim.decode_population(m)
-        self.assertEqual(m, dm)
-
-    def test_decode_already_individual(self):
-        m = pyslim.IndividualMetadata(pedigree_id=24, age=8, population=1,
-                                      sex=1, flags=0)
-        dm = pyslim.decode_individual(m)
-        self.assertEqual(m, dm)
-
-    def test_mutation_metadata(self):
-        for md_length in [0, 1, 5]:
-            md = [pyslim.MutationMetadata(
-                     mutation_type=j, selection_coeff=0.5, population=j,
-                     slim_time=10 + j, nucleotide=(j % 5) - 1) 
-                     for j in range(md_length)]
-            md_bytes = pyslim.encode_mutation(md)
-            new_md = pyslim.decode_mutation(md_bytes)
-            self.assertEqual(len(md), len(new_md))
-            for x, y in zip(md, new_md):
-                self.assertEqual(x, y)
-
-    def test_node_metadata(self):
-        md = pyslim.NodeMetadata(slim_id=2, is_null=False,
-                                 genome_type=pyslim.GENOME_TYPE_X)
-        md_bytes = pyslim.encode_node(md)
-        new_md = pyslim.decode_node(md_bytes)
-        self.assertEqual(md, new_md)
-
-    def test_individual_metadata(self):
-        md = pyslim.IndividualMetadata(
-                age=2, pedigree_id=23, population=0,
-                sex=pyslim.INDIVIDUAL_TYPE_MALE,
-                flags=pyslim.INDIVIDUAL_FLAG_MIGRATED)
-        md_bytes = pyslim.encode_individual(md)
-        new_md = pyslim.decode_individual(md_bytes)
-        self.assertEqual(md, new_md)
-
-    def test_population_metadata(self):
-        mrs = [pyslim.PopulationMigrationMetadata(source_subpop=j, migration_rate=0.2)
-               for j in range(3)]
-        for mr_list in [[], mrs]:
-            md = pyslim.PopulationMetadata(
-                    slim_id=1, selfing_fraction=0.75, female_cloning_fraction=0.2,
-                    male_cloning_fraction=0.8, sex_ratio=0.6, bounds_x0=-1.0,
-                    bounds_x1=2.0, bounds_y0=0.0, bounds_y1=0.0, bounds_z0=0.0,
-                    bounds_z1=1.0, migration_records=mr_list)
-            md_bytes = pyslim.encode_population(md)
-            new_md = pyslim.decode_population(md_bytes)
-            self.assertEqual(md, new_md)
-
-
-class TestAnnotate(tests.PyslimTestCase):
-    '''
-    Tests the table annotation methods.
-    '''
-
-    def test_annotate_mutations(self):
-        for ts in self.get_slim_examples():
-            tables = ts.tables
-            new_tables = ts.tables
-            metadata = []
-            for md in tskit.unpack_bytes(tables.mutations.metadata,
-                                           tables.mutations.metadata_offset):
-                dm = pyslim.decode_mutation(md)
-                edm = pyslim.encode_mutation(dm)
-                self.assertEqual(md, edm)
-                metadata.append(dm)
-
-            pyslim.annotate_mutation_metadata(new_tables, metadata)
-            self.assertEqual(tables, new_tables)
-
-    def test_annotate_nodes(self):
-        for ts in self.get_slim_examples():
-            tables = ts.tables
-            new_tables = ts.tables
-            metadata = []
-            for md in tskit.unpack_bytes(tables.nodes.metadata,
-                                           tables.nodes.metadata_offset):
-                dm = pyslim.decode_node(md)
-                edm = pyslim.encode_node(dm)
-                self.assertEqual(md, edm)
-                metadata.append(dm)
-
-            pyslim.annotate_node_metadata(new_tables, metadata)
-            self.assertEqual(tables, new_tables)
-
-    def test_annotate_individuals(self):
-        for ts in self.get_slim_examples():
-            tables = ts.tables
-            new_tables = ts.tables
-            metadata = []
-            for md in tskit.unpack_bytes(tables.individuals.metadata,
-                                           tables.individuals.metadata_offset):
-                dm = pyslim.decode_individual(md)
-                edm = pyslim.encode_individual(dm)
-                self.assertEqual(md, edm)
-                metadata.append(dm)
-
-            pyslim.annotate_individual_metadata(new_tables, metadata)
-            self.assertEqual(tables, new_tables)
-
-    def test_annotate_populations(self):
-        for ts in self.get_slim_examples():
-            tables = ts.tables
-            new_tables = ts.tables
-            metadata = []
-            for md in tskit.unpack_bytes(tables.populations.metadata,
-                                         tables.populations.metadata_offset):
-                dm = pyslim.decode_population(md)
-                edm = pyslim.encode_population(dm)
-                self.assertEqual(md, edm)
-                metadata.append(dm)
-
-            pyslim.annotate_population_metadata(new_tables, metadata)
-            self.assertTableCollectionsEqual(tables, new_tables)
-
-
 class TestDumpLoad(tests.PyslimTestCase):
     '''
     Test reading and writing.
     '''
 
     def setUp(self):
-        fd, self.temp_file = tempfile.mkstemp(prefix="msp_ll_ts_")
+        fd, self.temp_file = tempfile.mkstemp(prefix="pyslim_ts_")
         os.close(fd)
 
     def tearDown(self):
@@ -393,16 +251,16 @@ class TestNucleotides(tests.PyslimTestCase):
         '''
         for mut in ts.mutations():
             print(mut)
-            for u in mut.metadata:
-                self.assertGreaterEqual(u.nucleotide, -1)
-                self.assertLessEqual(u.nucleotide, 3)
+            for u in mut.metadata['mutation_list']:
+                self.assertGreaterEqual(u["nucleotide"], -1)
+                self.assertLessEqual(u["nucleotide"], 3)
 
     def test_nucleotides(self):
         for ts in self.get_slim_examples():
             self.check_nucleotides(ts)
 
 
-class TestLegacyDecoding(tests.PyslimTestCase):
+class TestDecoding(tests.PyslimTestCase):
     '''
     Test by comparing decoding to our previous direct implementation of struct decoding.
     '''
@@ -413,7 +271,8 @@ class TestLegacyDecoding(tests.PyslimTestCase):
         nt.metadata_schema = ms
         for a, b in zip(t, nt):
             md = a.metadata
-            omd = decoder(b.metadata)
+            with self.assertWarns(DeprecationWarning):
+                omd = decoder(b.metadata)
             if md is None:
                 self.assertTrue(omd is None)
             else:
@@ -425,7 +284,8 @@ class TestLegacyDecoding(tests.PyslimTestCase):
         nt.metadata_schema = ms
         for a, b in zip(t, nt):
             md = a.metadata
-            omd = pyslim.decode_mutation(b.metadata)
+            with self.assertWarns(DeprecationWarning):
+                omd = pyslim.decode_mutation(b.metadata)
             self.assertEqual(md,
                     {"mutation_list": [u.asdict() for u in omd]})
 

--- a/tests/test_metadata.py
+++ b/tests/test_metadata.py
@@ -296,3 +296,58 @@ class TestDecoding(tests.PyslimTestCase):
             self.verify_decoding(tables.individuals, pyslim.decode_individual)
             self.verify_decoding(tables.nodes, pyslim.decode_node)
             self.verify_mutation_decoding(tables.mutations)
+
+
+class TestMetadataAttributeError(tests.PyslimTestCase):
+
+    def test_population_error(self):
+        for ts in self.get_slim_examples():
+            for x in ts.populations():
+                if x.metadata is not None:
+                    with self.assertRaisesRegex(AttributeError, 'legacy'):
+                        _ = x.metadata.slim_id
+                    with self.assertRaisesRegex(AttributeError, 'legacy'):
+                        _ = x.metadata.selfing_fraction
+                    with self.assertRaisesRegex(AttributeError, 'legacy'):
+                        _ = x.metadata.sex_ratio
+                break
+            break
+
+    def test_individual_error(self):
+        for ts in self.get_slim_examples():
+            for x in ts.individuals():
+                with self.assertRaisesRegex(AttributeError, 'legacy'):
+                    _ = x.metadata.pedigree_id
+                with self.assertRaisesRegex(AttributeError, 'legacy'):
+                    _ = x.metadata.age
+                with self.assertRaisesRegex(AttributeError, 'legacy'):
+                    _ = x.metadata.subpopulation
+                with self.assertRaisesRegex(AttributeError, 'legacy'):
+                    _ = x.metadata.sex
+                with self.assertRaisesRegex(AttributeError, 'legacy'):
+                    _ = x.metadata.flags
+                break
+            break
+
+    def test_node_error(self):
+        for ts in self.get_slim_examples():
+            for x in ts.nodes():
+                if x.metadata is not None:
+                    with self.assertRaisesRegex(AttributeError, 'legacy'):
+                        _ = x.metadata.slim_id
+                    with self.assertRaisesRegex(AttributeError, 'legacy'):
+                        _ = x.metadata.is_null
+                    with self.assertRaisesRegex(AttributeError, 'legacy'):
+                        _ = x.metadata.genome_type
+                break
+            break
+
+    def test_mutation_error(self):
+        for ts in self.get_slim_examples():
+            for x in ts.mutations():
+                with self.assertRaisesRegex(KeyError, 'legacy'):
+                    _ = x.metadata[0]
+                with self.assertRaisesRegex(KeyError, 'legacy'):
+                    _ = x.metadata[999]
+                break
+            break


### PR DESCRIPTION
Closes #96.

Old scripts should still entirely work as long as `pyslim.load(...)` is replaced with `pyslim.load(..., legacy_metadata=True)`. All the old metadata handling raises DeprecationWarnings. 