### PR TITLE
speedup annotation

### DIFF
--- a/pyslim/slim_metadata.py
+++ b/pyslim/slim_metadata.py
@@ -386,7 +386,7 @@ def default_slim_metadata(name):
     elif name == "node":
         out = {
             "slim_id": tskit.NULL,
-            "is_null": True,
+            "is_null": False,
             "genome_type": 0,
         }
     elif name == "individual":

--- a/tests/benchmark/annotation.sh
+++ b/tests/benchmark/annotation.sh
@@ -1,0 +1,54 @@
+#!/bin/bash
+
+SETUP_SETUP="
+import msprime
+
+def setup():
+    ts = msprime.simulate(
+            2000,
+            Ne=1000,
+            length=1e8,
+            discrete_genome=True, 
+            recombination_rate=1e-8)
+    ts.dump('to_annotate.trees')
+    return 0
+"
+
+SETUP="
+import pyslim, tskit
+ts = tskit.load('to_annotate.trees')
+
+def pyslim_fn(ts):
+    tables = ts.tables
+    pyslim.annotate_defaults_tables(tables, model_type='WF', slim_generation=1)
+    return 0
+
+def tskit_fn(ts):
+    tables = ts.tables
+    dmd = {}
+    for k in ('node', 'individual', 'population'):
+        md = pyslim.default_slim_metadata(k)
+        ms = pyslim.slim_metadata_schemas[k]
+        dmd[k] = ms.validate_and_encode_row(md)
+
+    pop_md = [b'' for _ in tables.populations]
+    for p in set(tables.nodes.population):
+        pop_md[p] = dmd['population']
+    tables.populations.packset_metadata(pop_md)
+
+    node_md = [b'' if (n.flags & 1) else dmd['node'] for n in tables.nodes]
+    tables.nodes.packset_metadata(node_md)
+
+    ind_md = [dmd['individual']] * tables.individuals.num_rows
+    tables.individuals.packset_metadata(ind_md)
+    return 0
+    
+"
+echo "setup:"
+python3 -m timeit -s "$SETUP_SETUP" "setup()"
+
+echo "tskit:"
+python3 -m timeit -s "$SETUP" "tskit_fn(ts)"
+
+echo "pyslim:"
+python3 -m timeit -s "$SETUP" "pyslim_fn(ts)"

--- a/tests/test_annotation.py
+++ b/tests/test_annotation.py
@@ -119,6 +119,32 @@ class TestAnnotate(tests.PyslimTestCase):
             with self.assertRaises(ValueError):
                 _ = pyslim.annotate_defaults(ts, model_type=[],
                                              slim_generation=4)
+        # odd number of samples
+        ts = msprime.simulate(3)
+        with self.assertRaisesRegex(ValueError, "diploid"):
+            _ = pyslim.annotate_defaults(ts, model_type="WF",
+                                         slim_generation=1)
+        # inconsistent populations for diploids
+        ts = msprime.simulate(
+            population_configurations=[
+                msprime.PopulationConfiguration(sample_size=3),
+                msprime.PopulationConfiguration(sample_size=1)],
+            migration_matrix=[[0.0, 1.0], [1.0, 0.0]]
+            )
+        with self.assertRaisesRegex(ValueError, "more than one population"):
+            _ = pyslim.annotate_defaults(ts, model_type="WF",
+                                         slim_generation=1)
+        # inconsistent times for diploids
+        samples = [
+            msprime.Sample(population=0, time=0),
+            msprime.Sample(population=0, time=0),
+            msprime.Sample(population=0, time=0),
+            msprime.Sample(population=0, time=1),
+        ]
+        ts = msprime.simulate(samples=samples)
+        with self.assertRaisesRegex(ValueError, "more than one time"):
+            _ = pyslim.annotate_defaults(ts, model_type="WF",
+                                         slim_generation=1)
 
     def test_basic_annotation(self):
         for ts in self.get_msprime_examples():

--- a/tests/test_legacy_metadata.py
+++ b/tests/test_legacy_metadata.py
@@ -124,7 +124,7 @@ class TestEncodeDecode(LegacyPyslimTestCase):
                                      nucleotide = 2) for k in range(4)]
         with self.assertWarns(FutureWarning):
             dm = pyslim.decode_mutation(m)
-        self.assertEqual(type(dm), type([]))
+        self.assertTrue(isinstance(dm, list))
         for a, b in zip(m, dm):
             self.assertEqual(a, b)
 
@@ -317,10 +317,10 @@ class TestDumpLoad(LegacyPyslimTestCase):
 
     def test_load_tables(self):
         for ts in self.get_slim_examples():
-            self.assertTrue(type(ts) is pyslim.SlimTreeSequence)
+            self.assertTrue(isinstance(ts, pyslim.SlimTreeSequence))
             tables = ts.tables
             new_ts = pyslim.load_tables(tables, legacy_metadata=True)
-            self.assertTrue(type(new_ts) is pyslim.SlimTreeSequence)
+            self.assertTrue(isinstance(new_ts, pyslim.SlimTreeSequence))
             new_tables = new_ts.tables
             self.assertEqual(tables, new_tables)
 
@@ -329,7 +329,7 @@ class TestDumpLoad(LegacyPyslimTestCase):
             fn = ex['basename'] + ".trees"
             # load in msprime then switch
             msp_ts = tskit.load(fn)
-            self.assertTrue(type(msp_ts) is msprime.TreeSequence)
+            self.assertTrue(isinstance(msp_ts, tskit.TreeSequence))
             # transfer tables
             msp_tables = msp_ts.tables
             new_ts = pyslim.load_tables(msp_tables, legacy_metadata=True)
@@ -339,13 +339,13 @@ class TestDumpLoad(LegacyPyslimTestCase):
             self.assertTableCollectionsEqual(msp_tables, new_tables)
             # convert directly
             new_ts = pyslim.SlimTreeSequence(msp_ts)
-            self.assertTrue(type(new_ts) is pyslim.SlimTreeSequence)
+            self.assertTrue(isinstance(new_ts, pyslim.SlimTreeSequence))
             self.verify_times(msp_ts, new_ts)
             new_tables = new_ts.tables
             self.assertTableCollectionsEqual(msp_tables, new_tables)
             # load to pyslim from file
             slim_ts = pyslim.load(fn, legacy_metadata=True)
-            self.assertTrue(type(slim_ts) is pyslim.SlimTreeSequence)
+            self.assertTrue(isinstance(slim_ts, pyslim.SlimTreeSequence))
             slim_tables = slim_ts.tables
             self.assertTableCollectionsEqual(msp_tables, slim_tables)
             self.assertEqual(slim_ts.slim_generation, new_ts.slim_generation)

--- a/tests/test_metadata.py
+++ b/tests/test_metadata.py
@@ -188,10 +188,10 @@ class TestDumpLoad(tests.PyslimTestCase):
 
     def test_load_tables(self):
         for ts in self.get_slim_examples():
-            self.assertTrue(type(ts) is pyslim.SlimTreeSequence)
+            self.assertTrue(isinstance(ts, pyslim.SlimTreeSequence))
             tables = ts.tables
             new_ts = pyslim.load_tables(tables)
-            self.assertTrue(type(new_ts) is pyslim.SlimTreeSequence)
+            self.assertTrue(isinstance(new_ts, pyslim.SlimTreeSequence))
             new_tables = new_ts.tables
             self.assertEqual(tables, new_tables)
 
@@ -200,7 +200,7 @@ class TestDumpLoad(tests.PyslimTestCase):
             fn = ex['basename'] + ".trees"
             # load in msprime then switch
             msp_ts = tskit.load(fn)
-            self.assertTrue(type(msp_ts) is msprime.TreeSequence)
+            self.assertTrue(isinstance(msp_ts, tskit.TreeSequence))
             # transfer tables
             msp_tables = msp_ts.tables
             new_ts = pyslim.load_tables(msp_tables)
@@ -210,13 +210,13 @@ class TestDumpLoad(tests.PyslimTestCase):
             self.assertTableCollectionsEqual(msp_tables, new_tables)
             # convert directly
             new_ts = pyslim.SlimTreeSequence(msp_ts)
-            self.assertTrue(type(new_ts) is pyslim.SlimTreeSequence)
+            self.assertTrue(isinstance(new_ts, pyslim.SlimTreeSequence))
             self.verify_times(msp_ts, new_ts)
             new_tables = new_ts.tables
             self.assertTableCollectionsEqual(msp_tables, new_tables)
             # load to pyslim from file
             slim_ts = pyslim.load(fn)
-            self.assertTrue(type(slim_ts) is pyslim.SlimTreeSequence)
+            self.assertTrue(isinstance(slim_ts, pyslim.SlimTreeSequence))
             slim_tables = slim_ts.tables
             self.assertTableCollectionsEqual(msp_tables, slim_tables)
             self.assertEqual(slim_ts.slim_generation, new_ts.slim_generation)

--- a/tests/test_provenance.py
+++ b/tests/test_provenance.py
@@ -196,7 +196,7 @@ class TestProvenance(tests.PyslimTestCase):
         ts = msprime.simulate(10)
         for record_text in old_provenance_examples:
             record = json.loads(record_text)
-            prov = msprime.Provenance(timestamp='2018-08-25T14:59:13', record=json.dumps(record))
+            prov = tskit.Provenance(timestamp='2018-08-25T14:59:13', record=json.dumps(record))
             is_slim, version = pyslim.slim_provenance_version(prov)
             self.assertTrue(is_slim)
             if 'file_version' in record:
@@ -240,7 +240,7 @@ class TestProvenance(tests.PyslimTestCase):
             for _ in range(20):
                 u = random.sample(samples, 1)[0]
                 self.assertEqual(t.parent(u), pt.parent(u))
-                if t.parent(u) != msprime.NULL_NODE:
+                if t.parent(u) != tskit.NULL:
                     self.assertEqual(t.branch_length(u), pt.branch_length(u))
 
     def test_convert_0_2_files(self):
@@ -264,7 +264,7 @@ class TestProvenance(tests.PyslimTestCase):
             for _ in range(20):
                 u = random.sample(samples, 1)[0]
                 self.assertEqual(t.parent(u), pt.parent(u))
-                if t.parent(u) != msprime.NULL_NODE:
+                if t.parent(u) != tskit.NULL:
                     self.assertEqual(t.branch_length(u), pt.branch_length(u))
 
     def test_convert_0_3_files(self):
@@ -288,7 +288,7 @@ class TestProvenance(tests.PyslimTestCase):
             for _ in range(20):
                 u = random.sample(samples, 1)[0]
                 self.assertEqual(t.parent(u), pt.parent(u))
-                if t.parent(u) != msprime.NULL_NODE:
+                if t.parent(u) != tskit.NULL:
                     self.assertEqual(t.branch_length(u), pt.branch_length(u))
 
     def test_convert_0_4_files(self):
@@ -314,7 +314,7 @@ class TestProvenance(tests.PyslimTestCase):
             for _ in range(20):
                 u = random.sample(samples, 1)[0]
                 self.assertEqual(t.parent(u), pt.parent(u))
-                if t.parent(u) != msprime.NULL_NODE:
+                if t.parent(u) != tskit.NULL:
                     self.assertEqual(t.branch_length(u), pt.branch_length(u))
 
 


### PR DESCRIPTION
It was so TERRIBLY SLOW, turns out because of all those python for loops. This went form
```
$ tests/benchmark/annotation.sh 
setup:
1 loop, best of 5: 762 msec per loop
tskit:
2 loops, best of 5: 116 msec per loop
pyslim:
1 loop, best of 5: 25.6 sec per loop
```
to
```
$ tests/benchmark/annotation.sh 
setup:
1 loop, best of 5: 735 msec per loop
tskit:
2 loops, best of 5: 125 msec per loop
pyslim:
2 loops, best of 5: 115 msec per loop
```