### PR TITLE
Write VCF with nucleotides only

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,6 +2,12 @@
 [UPCOMING.X.X] - XXXX-XX-XX
 ***************************
 
+**Breaking changes**:
+
+- Added an argument to `SlimTreeSequence.write_vcf()` that by outputs
+  nucleotide alleles instead of the comma-separated strings of SLiM allele
+  numbers that were produced previously. (Note: vcf-writing code will be copied
+  from tskit, but only until available in a tskit release.)
 
 **New features**:
 
@@ -15,10 +21,10 @@
 **Bugfix**:
 
 - Making `.slim_generation` derive from the tree sequence's top-level metadata
-    had the unanticipated consequence that it could not be modified, which some
-    people were doing. This restores the previous behavior, but in the future,
-    modifying `.slim_generation` on a tree sequence will be deprecated - instead,
-    this should be modified in the metadata of the TableCollection.
+  had the unanticipated consequence that it could not be modified, which some
+  people were doing. This restores the previous behavior, but in the future,
+  modifying `.slim_generation` on a tree sequence will be deprecated - instead,
+  this should be modified in the metadata of the TableCollection.
 
 ********************
 [0.500] - 2020-12-07

--- a/pyslim/slim_tree_sequence.py
+++ b/pyslim/slim_tree_sequence.py
@@ -297,10 +297,14 @@ class SlimTreeSequence(tskit.TreeSequence):
                 idx = [0]
                 for a in variant.alleles:
                     alleles.append("".join([NUCLEOTIDES[i] for i in idx]))
-                    if idx[0] == 3:
-                        idx = [0] + idx
+                    j = 0
+                    while j < len(idx) and idx[j] == 3:
+                        idx[j] = 0
+                        j += 1
+                    if j < len(idx):
+                        idx[j] += 1
                     else:
-                        idx[0] += 1
+                        idx = idx + [0]
                 genotype_map = np.arange(len(alleles))
                 return alleles, np.array(genotype_map)
         writer = VcfWriter(self, **kwargs, allele_mapper=allele_mapper)

--- a/pyslim/vcf.py
+++ b/pyslim/vcf.py
@@ -1,0 +1,215 @@
+#
+# MIT License
+#
+# Copyright (c) 2019 Tskit Developers
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+"""
+Convert tree sequences to VCF.
+"""
+import numpy as np
+
+from . import provenance
+
+
+def legacy_position_transform(positions):
+    """
+    Transforms positions in the tree sequence into VCF coordinates under
+    the pre 0.2.0 legacy rule.
+    """
+    last_pos = 0
+    transformed = []
+    for pos in positions:
+        pos = int(round(pos))
+        if pos <= last_pos:
+            pos = last_pos + 1
+        transformed.append(pos)
+        last_pos = pos
+    return transformed
+
+
+class VcfWriter:
+    """
+    Writes a VCF representation of the genotypes tree sequence to a
+    file-like object.
+    """
+
+    def __init__(
+        self,
+        tree_sequence,
+        ploidy=None,
+        contig_id="1",
+        individuals=None,
+        individual_names=None,
+        position_transform=None,
+        allele_mapper=None,
+    ):
+        self.tree_sequence = tree_sequence
+        self.contig_id = contig_id
+
+        if individuals is None:
+            individuals = np.arange(tree_sequence.num_individuals, dtype=int)
+        self.individuals = individuals
+
+        self.__make_sample_mapping(ploidy)
+
+        if individual_names is None:
+            individual_names = [f"tsk_{j}" for j in range(self.num_individuals)]
+        self.individual_names = individual_names
+        if len(self.individual_names) != self.num_individuals:
+            raise ValueError(
+                "individual_names must have length equal to the number of individuals"
+            )
+
+        # Transform coordinates for VCF
+        if position_transform is None:
+            position_transform = np.round
+        elif position_transform == "legacy":
+            position_transform = legacy_position_transform
+        self.transformed_positions = np.array(
+            position_transform(tree_sequence.tables.sites.position), dtype=int
+        )
+        if self.transformed_positions.shape != (tree_sequence.num_sites,):
+            raise ValueError(
+                "Position transform must return an array of the same length"
+            )
+        self.contig_length = max(
+            1, int(position_transform([tree_sequence.sequence_length])[0])
+        )
+        if len(self.transformed_positions) > 0:
+            # Arguably this should be last_pos + 1, but if we hit this
+            # condition the coordinate systems are all muddled up anyway
+            # so it's simpler to stay with this rule that was inherited
+            # from the legacy VCF output code.
+            self.contig_length = max(self.transformed_positions[-1], self.contig_length)
+        if allele_mapper is None:
+            self.allele_mapper = lambda v: v.alleles
+        else:
+            self.allele_mapper = allele_mapper
+
+    def __make_sample_mapping(self, ploidy):
+        """
+        Compute the sample IDs for each VCF individual and the template for
+        writing out genotypes.
+        """
+        self.samples = None
+        self.individual_ploidies = []
+        if len(self.individuals) > 0:
+            if ploidy is not None:
+                raise ValueError("Cannot specify ploidy when individuals present")
+            self.samples = []
+            for i in self.individuals:
+                if i < 0 or i >= self.tree_sequence.num_individuals:
+                    raise ValueError("Invalid individual IDs provided.")
+                ind = self.tree_sequence.individual(i)
+                self.samples.extend(ind.nodes)
+                self.individual_ploidies.append(len(ind.nodes))
+            if len(self.samples) == 0:
+                raise ValueError("The individuals do not map to any sampled nodes.")
+        else:
+            if ploidy is None:
+                ploidy = 1
+            if ploidy < 1:
+                raise ValueError("Ploidy must be >= 1")
+            if self.tree_sequence.num_samples % ploidy != 0:
+                raise ValueError("Sample size must be divisible by ploidy")
+            self.individual_ploidies = [
+                ploidy for _ in range(self.tree_sequence.sample_size // ploidy)
+            ]
+        self.num_individuals = len(self.individual_ploidies)
+
+    def __write_header(self, output):
+        print("##fileformat=VCFv4.2", file=output)
+        print(f"##source=tskit {provenance.__version__}", file=output)
+        print('##FILTER=<ID=PASS,Description="All filters passed">', file=output)
+        print(
+            f"##contig=<ID={self.contig_id},length={self.contig_length}>", file=output
+        )
+        print(
+            '##FORMAT=<ID=GT,Number=1,Type=String,Description="Genotype">', file=output
+        )
+        vcf_samples = "\t".join(self.individual_names)
+        print(
+            "#CHROM",
+            "POS",
+            "ID",
+            "REF",
+            "ALT",
+            "QUAL",
+            "FILTER",
+            "INFO",
+            "FORMAT",
+            vcf_samples,
+            sep="\t",
+            file=output,
+        )
+
+    def write(self, output):
+        self.__write_header(output)
+
+        # Build the array for hold the text genotype VCF data and the indexes into
+        # this array for when we're updating it.
+        gt_array = []
+        indexes = []
+        for ploidy in self.individual_ploidies:
+            for _ in range(ploidy):
+                indexes.append(len(gt_array))
+                # First element here is a placeholder that we'll write the actual
+                # genotypes into when for each variant.
+                gt_array.extend([0, ord("|")])
+            gt_array[-1] = ord("\t")
+        gt_array[-1] = ord("\n")
+        gt_array = np.array(gt_array, dtype=np.int8)
+        # TODO Unclear here whether using int64 or int32 will be faster for this index
+        # array. Test it out.
+        indexes = np.array(indexes, dtype=int)
+
+        for variant in self.tree_sequence.variants(samples=self.samples):
+            if variant.has_missing_data:
+                raise ValueError(
+                    "Missing data is not currently supported. Please open an issue "
+                    "on GitHub if this limitation affects you."
+                )
+            pos = self.transformed_positions[variant.index]
+            alleles, genotype_map = self.allele_mapper(variant)
+            if len(alleles) > 9:
+                raise ValueError(
+                    "More than 9 alleles not currently supported. Please open an issue "
+                    "on GitHub if this limitation affects you."
+                )
+            ref = alleles[0]
+            alt = ",".join(alleles[1:])
+            print(
+                self.contig_id,
+                pos,
+                ".",
+                ref,
+                alt,
+                ".",
+                "PASS",
+                ".",
+                "GT",
+                sep="\t",
+                end="\t",
+                file=output,
+            )
+            gt_array[indexes] = genotype_map[variant.genotypes] + ord("0")
+            g_bytes = memoryview(gt_array).tobytes()
+            g_str = g_bytes.decode()
+            print(g_str, end="", file=output)

--- a/pyslim/vcf.py
+++ b/pyslim/vcf.py
@@ -99,7 +99,7 @@ class VcfWriter:
             # from the legacy VCF output code.
             self.contig_length = max(self.transformed_positions[-1], self.contig_length)
         if allele_mapper is None:
-            self.allele_mapper = lambda v: v.alleles
+            self.allele_mapper = lambda v: v.alleles, np.arange(len(v.alleles))
         else:
             self.allele_mapper = allele_mapper
 
@@ -195,6 +195,8 @@ class VcfWriter:
                 )
             ref = alleles[0]
             alt = ",".join(alleles[1:])
+            if len(alt) == 0:
+                alt = "."
             print(
                 self.contig_id,
                 pos,

--- a/requirements/CI/requirements.txt
+++ b/requirements/CI/requirements.txt
@@ -8,6 +8,7 @@ numpy==1.19.4
 pytest==6.1.2
 pytest-cov==2.10.1
 pytest-xdist==2.1.0
+PyVCF==0.6.8
 sphinx==3.3.1
 sphinx-argparse==0.2.5
 sphinx-issues==1.2.0

--- a/tests/test_vcf.py
+++ b/tests/test_vcf.py
@@ -1,0 +1,59 @@
+"""
+Test cases for VCF output in pyslim.
+"""
+import contextlib
+import io
+import tempfile
+
+import numpy as np
+import pytest
+import vcf
+
+
+@contextlib.contextmanager
+def ts_to_pyvcf(ts, *args, **kwargs):
+    """
+    Returns a PyVCF reader for the specified tree sequence and arguments.
+    """
+    f = io.StringIO()
+    ts.write_vcf(f, *args, **kwargs)
+    f.seek(0)
+    yield vcf.Reader(f)
+
+
+
+class TestRoundTripIndividuals(PyslimTestCase):
+    """
+    Tests that we can round-trip genotype data through VCF using pyvcf.
+    """
+
+    def verify(self, ts):
+        for indivs, _num_indivs in example_individuals(ts):
+            with ts_to_pyvcf(ts, individuals=indivs) as vcf_reader:
+                samples = []
+                if indivs is None:
+                    indivs = range(ts.num_individuals)
+                for ind in map(ts.individual, indivs):
+                    samples.extend(ind.nodes)
+                for variant, vcf_row in itertools.zip_longest(
+                    ts.variants(samples=samples), vcf_reader
+                ):
+                    assert vcf_row.POS == np.round(variant.site.position)
+                    assert variant.alleles[0] == vcf_row.REF
+                    assert list(variant.alleles[1:]) == vcf_row.ALT
+                    j = 0
+                    for individual, sample in itertools.zip_longest(
+                        map(ts.individual, indivs), vcf_row.samples
+                    ):
+                        calls = sample.data.GT.split("|")
+                        allele_calls = sample.gt_bases.split("|")
+                        assert len(calls) == len(individual.nodes)
+                        for allele_call, call in zip(allele_calls, calls):
+                            assert int(call) == variant.genotypes[j]
+                            assert allele_call == variant.alleles[variant.genotypes[j]]
+                            j += 1
+
+    def test_round_trip(self):
+        for ts in self.get_slim_examples(nucleotides=True):
+            self.verify(ts)
+

--- a/tests/test_vcf.py
+++ b/tests/test_vcf.py
@@ -1,11 +1,14 @@
 """
 Test cases for VCF output in pyslim.
 """
+
+import pyslim
 import contextlib
 import io
 import tempfile
-
 import numpy as np
+import itertools
+import tests
 import pytest
 import vcf
 
@@ -21,15 +24,27 @@ def ts_to_pyvcf(ts, *args, **kwargs):
     yield vcf.Reader(f)
 
 
+def example_individuals(ts, ploidy=1):
+    if ts.num_individuals == 0:
+        yield None, ts.num_samples / ploidy
+    else:
+        yield None, ts.num_individuals
+        yield list(range(ts.num_individuals)), ts.num_individuals
+    if ts.num_individuals > 3:
+        n = ts.num_individuals - 2
+        yield list(range(n)), n
+        yield 2 + np.random.choice(np.arange(n), n, replace=False), n
 
-class TestRoundTripIndividuals(PyslimTestCase):
+
+class TestNucleotideBased(tests.PyslimTestCase):
     """
-    Tests that we can round-trip genotype data through VCF using pyvcf.
+    Tests that we can round-trip genotype data through VCF using pyvcf
+    for nucleotide models.
     """
 
     def verify(self, ts):
         for indivs, _num_indivs in example_individuals(ts):
-            with ts_to_pyvcf(ts, individuals=indivs) as vcf_reader:
+            with ts_to_pyvcf(ts, individuals=indivs, nucleotide_based=True) as vcf_reader:
                 samples = []
                 if indivs is None:
                     indivs = range(ts.num_individuals)
@@ -39,8 +54,12 @@ class TestRoundTripIndividuals(PyslimTestCase):
                     ts.variants(samples=samples), vcf_reader
                 ):
                     assert vcf_row.POS == np.round(variant.site.position)
-                    assert variant.alleles[0] == vcf_row.REF
-                    assert list(variant.alleles[1:]) == vcf_row.ALT
+                    assert ts.reference_sequence[int(variant.site.position)] == vcf_row.REF
+                    alleles = [ts.reference_sequence[int(variant.site.position)]] 
+                    alleles += ["".join(
+                            [pyslim.NUCLEOTIDES[u['nucleotide']] for u in m.metadata['mutation_list']]
+                        ) for m in variant.site.mutations]
+                    vcf_alleles = [vcf_row.REF] + vcf_row.ALT
                     j = 0
                     for individual, sample in itertools.zip_longest(
                         map(ts.individual, indivs), vcf_row.samples
@@ -49,11 +68,55 @@ class TestRoundTripIndividuals(PyslimTestCase):
                         allele_calls = sample.gt_bases.split("|")
                         assert len(calls) == len(individual.nodes)
                         for allele_call, call in zip(allele_calls, calls):
-                            assert int(call) == variant.genotypes[j]
-                            assert allele_call == variant.alleles[variant.genotypes[j]]
+                            assert vcf_alleles[int(call)] == alleles[variant.genotypes[j]]
+                            assert allele_call == alleles[variant.genotypes[j]]
                             j += 1
 
     def test_round_trip(self):
         for ts in self.get_slim_examples(nucleotides=True):
             self.verify(ts)
+
+
+class TestNonNucleotideBased(tests.PyslimTestCase):
+    """
+    Tests that we can round-trip genotype data through VCF using pyvcf
+    for non-nucleotide models.
+    """
+
+    def verify(self, ts):
+        for indivs, _num_indivs in example_individuals(ts):
+            with ts_to_pyvcf(ts, individuals=indivs, nucleotide_based=False) as vcf_reader:
+                samples = []
+                if indivs is None:
+                    indivs = range(ts.num_individuals)
+                for ind in map(ts.individual, indivs):
+                    samples.extend(ind.nodes)
+                for variant, vcf_row in itertools.zip_longest(
+                    ts.variants(samples=samples), vcf_reader
+                ):
+                    assert vcf_row.POS == np.round(variant.site.position)
+                    assert pyslim.NUCLEOTIDES[0] == vcf_row.REF
+                    vcf_alleles = [vcf_row.REF] + vcf_row.ALT
+                    vcf_genotypes = []
+                    for a in vcf_alleles:
+                        n = 0
+                        b = 1
+                        for x in str(a):
+                            n += pyslim.NUCLEOTIDES.index(x) * b
+                            b *= 4
+                        vcf_genotypes.append(n)
+                    j = 0
+                    for individual, sample in itertools.zip_longest(
+                        map(ts.individual, indivs), vcf_row.samples
+                    ):
+                        calls = sample.data.GT.split("|")
+                        allele_calls = sample.gt_bases.split("|")
+                        assert len(calls) == len(individual.nodes)
+                        for allele_call, call in zip(allele_calls, calls):
+                            assert vcf_genotypes[int(call)] == variant.genotypes[j]
+                            j += 1
+
+    def test_round_trip(self):
+        ts = self.get_slim_example(name="recipe_WF")
+        self.verify(ts)
 


### PR DESCRIPTION
This closes #73, and fixes up a few other things in VCF also.

I copied the write_vcf code from tskit for this, and now that I've got worked out a nice way to do it, would like to propose merging those changes back into tskit. The addition is an `allele_mapper` argument to `write_vcf`. The `allele_mapper` argument should be a function that takes a *variant* and returns `alleles, genotype_map`, where:
- `alleles` is a list of (unique) alleles, reference allele first, and
- `genotype_map` is a numpy array such that a sample with genotype index `j` (i.e., with allele `variant.site.mutations[j].derived_state` in the tree sequence) should in fact have in the VCF allele `alleles[genotype_map[j]]`.

This makes it pretty easy to output nucleotide-only VCFs.