### PR TITLE
Correct old terminology

### DIFF
--- a/docs/tutorial.rst
+++ b/docs/tutorial.rst
@@ -635,7 +635,7 @@ are not coalescent points in a tree (so-called "unary nodes"). Similarly, if you
 decide to reduce the number of samples via :ref:`sec_tutorial_simplification`,
 retained individuals will be kept only if they are still MRCAs in the ancestry of the
 selected samples. To preserve them even if their nodes are not coalescent points, you
-can specify ``ts.simplify(selected_samples, keep_unary="individuals")``.
+can specify ``ts.simplify(selected_samples, keep_unary_in_individuals=True)``.
 
 .. todo::
     Add SLiM code which includes retaining and remembering, and perhaps some python code


### PR DESCRIPTION
Reading through the docs, I forgot to change the to the new tskit syntax. Only relevant once tskit 0.3.5 has been released, but hopefully that'll be quite soon, so we might as well correct it.