### PR TITLE
slim file version bump

### DIFF
--- a/pyslim/_version.py
+++ b/pyslim/_version.py
@@ -1,3 +1,5 @@
 # coding: utf-8
 pyslim_version = '0.501'
-slim_file_version = '0.5'
+slim_file_version = '0.6'
+# other file versions that require no modification
+compatible_slim_file_versions = ['0.5', '0.6']

--- a/pyslim/slim_tree_sequence.py
+++ b/pyslim/slim_tree_sequence.py
@@ -155,7 +155,7 @@ class SlimTreeSequence(tskit.TreeSequence):
     def __init__(self, ts, reference_sequence=None, legacy_metadata=False):
         self.legacy_metadata = legacy_metadata
         if not (isinstance(ts.metadata, dict) and 'SLiM' in ts.metadata
-                and ts.metadata['SLiM']['file_version'] == slim_file_version):
+                and ts.metadata['SLiM']['file_version'] in compatible_slim_file_versions):
             tables = ts.dump_tables()
             if not (isinstance(tables.metadata, dict) and 'SLiM' in tables.metadata):
                 _set_metadata_from_provenance(tables)


### PR DESCRIPTION
To accomodate https://github.com/MesserLab/SLiM/commit/f43d3f9635dff73bf578c11b0f8babef487c7c6d

(The only difference is in the situations that an individual flag would be added, so no further changes are necessary.)