### PR TITLE
regenerate example tree sequences

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -30,16 +30,16 @@ jobs:
             if [ ! -e /home/circleci/.local/SLiM.hash ]; then
               git rev-parse HEAD > /home/circleci/.local/SLiM.hash
             fi
-            if [ $(git rev-list HEAD...$(cat /home/circleci/.local/SLiM.hash) --count) -gt 0 ]; then
-              mkdir build
+            if [ $(git rev-list HEAD...$(cat /home/circleci/.local/SLiM.hash) --count) -gt 0 -o ! -e /home/circleci/.local/bin/slim ]; then
+              mkdir -p build
               cd build
               cmake ..
               make
               cp slim /home/circleci/.local/bin/
             else
               echo "Restoring SLiM from cache:"
-              slim -v
             fi
+            slim -v
             git rev-parse HEAD > /home/circleci/.local/SLiM.hash
 
       - save_cache:

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -4,11 +4,11 @@ PYPATH=${PWD}/..
 PYSLIM_VERSION:=$(shell PYTHONPATH=${PYPATH} \
    python3 -c 'import pyslim; print(pyslim.__version__.split("+")[0])')
 
-dev:
+dev: prereqs
 	$(MAKE) -C _static
 	PYTHONPATH=${PYPATH} ./build.sh
 
-dist:
+dist: prereqs
 	@echo Building distribution for pyslim version ${PYSLIM_VERSION}
 	sed -i s/__PYSLIM_VERSION__/${PYSLIM_VERSION}/g _config.yml
 	$(MAKE) -C _static
@@ -16,3 +16,6 @@ dist:
 
 clean:
 	rm -fR _build
+
+prereqs:
+	slim -s 23 example_sim.slim


### PR DESCRIPTION
This is to deal with https://github.com/tskit-dev/tskit-site/pull/49 - the different pages were depending on the same example tree sequence, but if the one that actually produced the example wasn't run first, then, well, it wasn't there. Maybe there's a better way to do this?