### PR TITLE
max_slim_mutation_id function

### DIFF
--- a/pyslim/methods.py
+++ b/pyslim/methods.py
@@ -608,20 +608,24 @@ def annotate_tables(tables, model_type, tick, cycle=None, stage="early", referen
     if reference_sequence is not None:
         tables.reference_sequence.data = reference_sequence
 
-def max_slim_mutation_id(ts):
+def next_slim_mutation_id(ts):
     '''
-    Returns the largest SLiM mutation ID in this tree sequence. This is useful because
-    if you want to add more mutations to your tree sequence using :func:`msprime.sim_mutations`,
-    you may need to specify the parameter `next_id` in your 
-    :class:`msprime.SLiMMutationModel` to be larger than any existing mutation IDs.
-    Setting `next_id` equal to the output of this function + 1
-    will allow the mutated tree sequence to be read in by SLiM. 
+    Returns the next SLiM mutation ID for this tree sequence. This is useful 
+    because if you want to add more mutations to your SLiM tree sequence using 
+    :func:`msprime.sim_mutations`, you may need to specify the parameter 
+    `next_id` in your :class:`msprime.SLiMMutationModel` to be larger than any 
+    existing mutation IDs. Setting `next_id` equal to the output of this 
+    function will allow the mutated tree sequence to be read in by SLiM. Note
+    that this function does not work with non-SLiM tree sequences.
     '''
     max_id = -1
     for mut in ts.mutations():
         for d in mut.derived_state.split(","):
-            max_id = max(max_id, int(d))
-    return(max_id)
+            try:
+                max_id = max(max_id, int(d))
+            except ValueError:
+                raise ValueError("The derived states of mutations in the tree sequence need to be coercible to int. This is not a valied SLiM tree sequence.")
+    return(max_id+1)
 
 
 def _annotate_nodes_individuals(tables, age):

--- a/pyslim/methods.py
+++ b/pyslim/methods.py
@@ -608,6 +608,21 @@ def annotate_tables(tables, model_type, tick, cycle=None, stage="early", referen
     if reference_sequence is not None:
         tables.reference_sequence.data = reference_sequence
 
+def max_slim_mutation_id(ts):
+    '''
+    Returns the largest SLiM mutation ID in this tree sequence. This is useful because
+    if you want to add more mutations to your tree sequence using :func:`msprime.sim_mutations`,
+    you may need to specify the parameter `next_id` in your 
+    :class:`msprime.SLiMMutationModel` to be larger than any existing mutation IDs.
+    Setting `next_id` equal to the output of this function + 1
+    will allow the mutated tree sequence to be read in by SLiM. 
+    '''
+    max_id = -1
+    for mut in ts.mutations():
+        for d in mut.derived_state.split(","):
+            max_id = max(max_id, int(d))
+    return(max_id)
+
 
 def _annotate_nodes_individuals(tables, age):
     '''

--- a/pyslim/methods.py
+++ b/pyslim/methods.py
@@ -615,8 +615,11 @@ def next_slim_mutation_id(ts):
     :func:`msprime.sim_mutations`, you may need to specify the parameter 
     `next_id` in your :class:`msprime.SLiMMutationModel` to be larger than any 
     existing mutation IDs. Setting `next_id` equal to the output of this 
-    function will allow the mutated tree sequence to be read in by SLiM. Note
-    that this function does not work with non-SLiM tree sequences.
+    function will allow the mutated tree sequence to be read in by SLiM.
+    To do this, recall that the "derived state" of SLiM's mutations are
+    comma-separated strings of mutation IDs; this function just parses all derived
+    states and returns one larger than the largest integer found. It will return an error
+    if it encounters derived states that are not comma-separated strings of integers.
     '''
     max_id = -1
     for mut in ts.mutations():

--- a/pyslim/methods.py
+++ b/pyslim/methods.py
@@ -625,7 +625,7 @@ def next_slim_mutation_id(ts):
                 max_id = max(max_id, int(d))
             except ValueError:
                 raise ValueError("The derived states of mutations in the tree sequence need to be coercible to int. This is not a valied SLiM tree sequence.")
-    return(max_id+1)
+    return max_id + 1
 
 
 def _annotate_nodes_individuals(tables, age):

--- a/pyslim/methods.py
+++ b/pyslim/methods.py
@@ -621,11 +621,11 @@ def next_slim_mutation_id(ts):
     states and returns one larger than the largest integer found. It will return an error
     if it encounters derived states that are not comma-separated strings of integers.
     '''
-    max_id = -1
+    max_id = 0
     for mut in ts.mutations():
         for d in mut.derived_state.split(","):
             try:
-                max_id = max(max_id, int(d))
+                max_id = max(max_id, int(d or 0)) # the or zero will allow empty strings to be converted
             except ValueError:
                 raise ValueError("The derived states of mutations in the tree "
                                  "sequence need to be coercible to int. This "

--- a/pyslim/methods.py
+++ b/pyslim/methods.py
@@ -624,7 +624,8 @@ def next_slim_mutation_id(ts):
             try:
                 max_id = max(max_id, int(d))
             except ValueError:
-                raise ValueError("The derived states of mutations in the tree sequence need to be coercible to int. This is not a valied SLiM tree sequence.")
+                raise ValueError("The derived states of mutations in the tree sequence "
+                                           "need to be coercible to int. This is not a valid SLiM tree sequence.")
     return max_id + 1
 
 

--- a/pyslim/methods.py
+++ b/pyslim/methods.py
@@ -623,13 +623,15 @@ def next_slim_mutation_id(ts):
     '''
     max_id = 0
     for mut in ts.mutations():
-        for d in mut.derived_state.split(","):
-            try:
-                max_id = max(max_id, int(d or 0)) # the or zero will allow empty strings to be converted
-            except ValueError:
-                raise ValueError("The derived states of mutations in the tree "
-                                 "sequence need to be coercible to int. This "
-                                 "is not a valid SLiM tree sequence.")
+        ds = mut.derived_state
+        if len(ds) > 0:
+            for d in ds.split(","):
+                try:
+                    max_id = max(max_id, int(d))
+                except ValueError:
+                    raise ValueError(f"The derived state of a mutation ({ds}) in the tree "
+                                     "sequence is not a comma-separated list of values "
+                                     "coercible to int. This is not a valid SLiM tree sequence.")
     return max_id + 1
 
 

--- a/pyslim/methods.py
+++ b/pyslim/methods.py
@@ -627,8 +627,9 @@ def next_slim_mutation_id(ts):
             try:
                 max_id = max(max_id, int(d))
             except ValueError:
-                raise ValueError("The derived states of mutations in the tree sequence "
-                                           "need to be coercible to int. This is not a valid SLiM tree sequence.")
+                raise ValueError("The derived states of mutations in the tree "
+                                 "sequence need to be coercible to int. This "
+                                 "is not a valid SLiM tree sequence.")
     return max_id + 1
 
 

--- a/tests/test_recipes/restart_nucleotides_WF.slim
+++ b/tests/test_recipes/restart_nucleotides_WF.slim
@@ -9,6 +9,7 @@ initialize()
     initializeTreeSeq();
 	initializeAncestralNucleotides(paste0(rep("A", L)));
 	initializeMutationTypeNuc("m1", 0.5, "f", 0.0);
+    initializeMutationTypeNuc("m2", 0.5, "n", 0.0, 0.1);
 	initializeGenomicElementType("g1", m1, 1.0, mmJukesCantor(4e-2));
 	initializeGenomicElement(g1, 0, L-1);
 	initializeRecombinationRate(1e-2);

--- a/tests/test_tree_sequence.py
+++ b/tests/test_tree_sequence.py
@@ -36,13 +36,12 @@ class TestNextMutationID(tests.PyslimTestCase):
     '''
     Tests for the function that returns the largest SLiM mutation ID.
     '''
-    @pytest.mark.parametrize('recipe', [next(recipe_eq())], indirect=True)
     def test_next_id(self, recipe):
         ts = recipe["ts"]
         mt_ids_str = ','.join(tskit.unpack_strings(ts.tables.mutations.derived_state, ts.tables.mutations.derived_state_offset))
         mt_ids = [int(i) for i in mt_ids_str.split(',')]
         max_mt_id = max(mt_ids)
-        assert max_mt_id+1 == pyslim.next_slim_mutation_id(ts)
+        assert max_mt_id + 1 == pyslim.next_slim_mutation_id(ts)
 
     @pytest.mark.parametrize('recipe', recipe_eq("adds_mutations"), indirect=True)
     def test_reload_slim(self, recipe, helper_functions, tmp_path):

--- a/tests/test_tree_sequence.py
+++ b/tests/test_tree_sequence.py
@@ -82,7 +82,7 @@ class TestNextMutationID(tests.PyslimTestCase):
                     model="jc69",
                     rate=0.5,
                     random_seed=23)
-            with pytest.raises(ValueError):
+            with pytest.raises(ValueError, match="need to be coercible to int"):
                 pyslim.next_slim_mutation_id(mts)
 
 class TestRecapitate(tests.PyslimTestCase):

--- a/tests/test_tree_sequence.py
+++ b/tests/test_tree_sequence.py
@@ -39,7 +39,7 @@ class TestNextMutationID(tests.PyslimTestCase):
     def test_next_id(self, recipe):
         ts = recipe["ts"]
         mt_ids_str = ','.join(tskit.unpack_strings(ts.tables.mutations.derived_state, ts.tables.mutations.derived_state_offset))
-        mt_ids = [int(i) for i in mt_ids_str.split(',')]
+        mt_ids = [int(i or 0) for i in mt_ids_str.split(',')]
         max_mt_id = max(mt_ids)
         assert max_mt_id + 1 == pyslim.next_slim_mutation_id(ts)
 


### PR DESCRIPTION
Creates a function that returns the maximum SLiM mutation ID. Useful for adding more mutations with `msprime.sim_mutations()`.

Solves #179 