### PR TITLE
refactor of GH test action workflow

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -6,17 +6,36 @@ on:
     branches: [main]
 
 jobs:
-
   test:
     name: Python
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        python: [ 3.8, 3.9 ]
-        os:  [ macos-latest, ubuntu-latest ]
+        python: [3.8, 3.9]
+        os: [macos-latest, ubuntu-latest, windows-latest]
+        sys: [mingw64, ucrt64]
+        env: [x86_64, ucrt-x86_64]
+        exclude:
+          - os: macos-latest
+            sys: ucrt64
+          - os: macos-latest
+            sys: mingw64
+            env: ucrt-x86_64
+          - os: ubuntu-latest
+            sys: ucrt64
+          - os: ubuntu-latest
+            sys: mingw64
+            env: ucrt-x86_64
+          - os: windows-latest
+            sys: ucrt64
+            env: x86_64
+          - os: windows-latest
+            sys: mingw64
+            env: ucrt-x86_64
+
     defaults:
       run:
-        shell: bash
+        shell: bash -l {0}
     steps:
       - name: Cancel Previous Runs
         uses: styfle/cancel-workflow-action@0.6.0
@@ -25,80 +44,64 @@ jobs:
 
       - name: Checkout
         uses: actions/checkout@v2
-        with:
-          submodules: true
-
-      - name: Cache conda and dependancies
-        id: cache
-        uses: actions/cache@v2
-        env:
-          # Increase this to reset the cache if the key hasn't changed.
-          CACHE_NUM: 4
-        with:
-          path: |
-            c:\Miniconda\envs\anaconda-client-env
-            /usr/share/miniconda/envs/anaconda-client-env
-            ~/osx-conda
-            ~/.profile
-          key: ${{ runner.os }}-${{ matrix.python}}-conda-v${{ env.CACHE_NUM }}-${{ hashFiles('requirements/CI-pip/requirements.txt') }}-${{ hashFiles('requirements/CI-conda/requirements.txt') }}-${{ hashFiles('requirements/CI-docs/requirements.txt') }}
 
       - name: Install Conda
-        uses: conda-incubator/setup-miniconda@v2
-        if: steps.cache.outputs.cache-hit != 'true'
+        uses: mamba-org/provision-with-micromamba@main
         with:
-          activate-environment: anaconda-client-env
-          python-version: ${{ matrix.python }}
-          channels: conda-forge
-          channel-priority: strict
-          auto-update-conda: true
-          use-only-tar-bz2: true
+          environment-name: anaconda-client-env
+          environment-file: requirements/CI-conda/ci-environment.yml
+          cache-env: true
+          extra-specs: |
+            python=${{ matrix.python }}
 
-      - name: Fix windows .profile
-        if: steps.cache.outputs.cache-hit != 'true' && matrix.os == 'windows-latest'
+      - name: Setup MSYS2 ${{matrix.sys}}
+        uses: msys2/setup-msys2@v2
+        if: matrix.os == 'windows-latest'
+        with:
+          msystem: ${{matrix.sys}}
+          release: false
+          install: >-
+            git
+            base-devel
+            msys2-devel
+            mingw-w64-${{matrix.env}}-zstd
+            mingw-w64-${{matrix.env}}-zlib
+            mingw-w64-${{matrix.env}}-toolchain
+            mingw-w64-${{matrix.env}}-cmake
+            mingw-w64-${{matrix.env}}-autotools
+
+      - name: Cache SLiM build
+        if: matrix.os == 'windows-latest'
+        id: cache-slim
+        uses: actions/cache@v3.0.5 # latest version is broken https://github.com/actions/cache/issues/891, so pinning to 3.0.5
+        with:
+          path: D:\a\pyslim\pyslim\SLiM
+          key: ${{runner.os}}-${{matrix.sys}}-${{matrix.env}}-key
+
+      - name: Build SLiM windows
+        if: ( matrix.os == 'windows-latest'  && steps.cache-slim.outputs.cache-hit != 'true' )
+        shell: msys2 {0}
         run: |
-          cp ~/.bash_profile ~/.profile
+          git clone https://github.com/messerlab/SLiM.git
+          mkdir -p SLiM/Release
+          cd SLiM/windows_compat/gnulib
+          touch --date="`date`" aclocal.m4 Makefile.am configure configure.ac config.h.in Makefile.in
+          cd ../..
+          cd Release
+          cmake -G"MSYS Makefiles" -DCMAKE_BUILD_TYPE=Release ..
+          make -j 2
 
-      - name: Install conda deps
-        if: steps.cache.outputs.cache-hit != 'true'
-        shell: bash -l {0} #We need a login shell to get conda
+      - name: Install SLiM macos / linux
+        if: (matrix.os == 'macos-latest' || matrix.os == 'ubuntu-latest')
         run: |
-          if [ "$RUNNER_OS" != "Windows" ]; then
-            conda install --yes slim
-          fi
-          conda install --yes --file=requirements/CI-conda/requirements.txt
-
-      - name: Install pip deps
-        if: steps.cache.outputs.cache-hit != 'true'
-        shell: bash -l {0}
-        run: |
-          pip install -r requirements/CI-pip/requirements.txt
-          pip install -r requirements/CI-docs/requirements.txt
-
-      - name: Fix OSX Cache Write #OSX Won't let the cache restore due to file perms
-        if: steps.cache.outputs.cache-hit != 'true' && matrix.os == 'macos-latest'
-        run: |
-          cp -r /usr/local/miniconda/envs/anaconda-client-env ~/osx-conda
-
-      - name: Fix OSX Cache Restore
-        if: steps.cache.outputs.cache-hit == 'true' && matrix.os == 'macos-latest'
-        run: |
-          mkdir -p /usr/local/miniconda/envs
-          sudo cp -r ~/osx-conda /usr/local/miniconda/envs/anaconda-client-env
-
-      # retaining this for the next devel cycle
-      # - name: Build SLiM
-      #   run: |
-      #     git clone https://github.com/messerlab/SLiM.git
-      #     cd SLiM
-      #     mkdir -p Release
-      #     cd Release
-      #     cmake -D CMAKE_BUILD_TYPE=Release ..
-      #     make -j 2
+          micromamba install slim -y
 
       - name: Run tests
+        shell: bash -l {0}
         run: |
-          source ~/.profile
-          conda activate anaconda-client-env
-          export PATH=$PWD/SLiM/Release:$PATH
+          micromamba info
+          micromamba list
+          export PATH=$PWD/SLiM/Release:$PATH 
+          which slim
           slim -v
           pytest -xv -n2 tests

--- a/requirements/CI-conda/ci-environment.yml
+++ b/requirements/CI-conda/ci-environment.yml
@@ -1,0 +1,16 @@
+name: anaconda-client-env
+channels:
+  - conda-forge
+  - anaconda
+  - defaults
+dependencies:
+  - tskit>=0.5.2
+  - msprime>=1.2.0
+  - matplotlib==3.5.0
+  - pandas
+  - numpy
+  - flake8==3.8.4
+  - pytest==6.2.5
+  - pytest-cov==2.10.1
+  - pytest-xdist==2.5.0
+  - filelock

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -141,11 +141,15 @@ def run_slim(recipe, out_dir, recipe_dir="test_recipes", species=None, **kwargs)
     slim_vars = []
     for o in outfiles:
         if o.slim_name != "":
-            slim_vars += ["-d", f"{o.slim_name}=\"{o.path}\""]
+            # for happy windows filepaths
+            tmp_str = o.path.replace('\\', '\\\\')
+            slim_vars += ["-d", f"{o.slim_name}=\"{tmp_str}\""]
     for k in kwargs:
         x = kwargs[k]
         if x is not None:
             if isinstance(x, str) and x[:10] != 'Dictionary':
+                # for happy windows filepaths
+                x = x.replace('\\', '\\\\')
                 x = f"'{x}'"
             if isinstance(x, bool):
                 x = 'T' if x else 'F'
@@ -192,6 +196,8 @@ class HelperFunctions:
         # on it, saving to files in out_dir.
         infile = os.path.join(out_dir, "in.trees")
         in_ts.dump(infile)
+        # for happy windows filepaths       
+        infile_str = infile.replace('\\', '\\\\')
         kwargs['TREES_IN'] = infile
         if 'STAGE' not in kwargs:
             kwargs['STAGE'] = in_ts.metadata['SLiM']['stage']
@@ -211,7 +217,11 @@ class HelperFunctions:
         for sp in in_ts:
             infiles[sp] = os.path.join(out_dir, f"{sp}_in.trees")
             in_ts[sp].dump(infiles[sp])
-        kwargs['TREES_IN'] = _dict_to_eidos(infiles)
+        infiles_str_dict = {}
+        for k, v in infiles.items():
+            # for happy windows filepaths
+            infiles_str_dict[k] = v.replace('\\', '\\\\')        
+        kwargs['TREES_IN'] = _dict_to_eidos(infiles_str_dict)
         if 'STAGE' not in kwargs:
             kwargs['STAGE'] = in_ts[sp].metadata['SLiM']['stage']
         if subpop_map is not None:


### PR DESCRIPTION
Okay this is a brand new, spiffy workflow that allows for a few things:

1. `SLiM` is now built in windows environments and `pyslim` tests run on that executable
2. `micromamba` replaces `miniconda` as the package manager. this leads to considerable speed ups.
3. caching now works properly across all systems. to make this work without ugly hacks, i've had to pin the GH `actions/cache` to version `3.0.5`. this is noted in the code and the GH issue covering the issue (i.e. new version breaks everything on windows) is cited. 

@petrelharp this is now done! 