### PR TITLE
updates to demo use of meanParentAge

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -33,7 +33,7 @@ jobs:
         uses: actions/cache@v2
         env:
           # Increase this to reset the cache if the key hasn't changed.
-          CACHE_NUM: 1
+          CACHE_NUM: 2
         with:
           path: |
             c:\Miniconda\envs\anaconda-client-env

--- a/docs/generation_time.slim
+++ b/docs/generation_time.slim
@@ -1,9 +1,8 @@
 initialize() {
-	if(!exists("mu")) defineConstant("mu", 0.0);
 	initializeSLiMModelType("nonWF");
 	initializeSex("A");
 	initializeTreeSeq();
-	initializeMutationRate(mu);
+	initializeMutationRate(2e-8);
 	initializeMutationType("m1", 0.5, "f", 0.0);
 	initializeGenomicElementType("g1", m1, 1.0);
 	initializeGenomicElement(g1, 0, 1e8-1);

--- a/docs/generation_time.slim
+++ b/docs/generation_time.slim
@@ -1,8 +1,9 @@
 initialize() {
+	if(!exists("mu")) defineConstant("mu", 0.0);
 	initializeSLiMModelType("nonWF");
 	initializeSex("A");
 	initializeTreeSeq();
-	initializeMutationRate(0.0);
+	initializeMutationRate(mu);
 	initializeMutationType("m1", 0.5, "f", 0.0);
 	initializeGenomicElementType("g1", m1, 1.0);
 	initializeGenomicElement(g1, 0, 1e8-1);

--- a/docs/generation_time.slim
+++ b/docs/generation_time.slim
@@ -1,42 +1,40 @@
 initialize() {
-   initializeSLiMModelType("nonWF");
-   initializeSex("A");
-   initializeTreeSeq();
-   initializeMutationRate(0.0);
-   initializeMutationType("m1", 0.5, "f", 0.0);
-   initializeGenomicElementType("g1", m1, 1.0);
-   initializeGenomicElement(g1, 0, 1e8-1);
-   initializeRecombinationRate(1e-8);    
-   defineConstant("K", 1000);
-   defineGlobal("GENTIME", rep(NAN, 100));
+	initializeSLiMModelType("nonWF");
+	initializeSex("A");
+	initializeTreeSeq();
+	initializeMutationRate(0.0);
+	initializeMutationType("m1", 0.5, "f", 0.0);
+	initializeGenomicElementType("g1", m1, 1.0);
+	initializeGenomicElement(g1, 0, 1e8-1);
+	initializeRecombinationRate(1e-8);
+	defineConstant("K", 1000);
+	defineGlobal("GENTIME", rep(NAN, 100));
 }
 
 reproduction(p1, "F") {
-   for (k in seqLen(rpois(1, individual.age))) {
-      mate = subpop.sampleIndividuals(1, sex="M");
-      offspring = subpop.addCrossed(individual, mate);
-      offspring.tagF = (individual.age + mate.age) / 2;
-   }
+	for (k in seqLen(rpois(1, individual.age))) {
+		mate = subpop.sampleIndividuals(1, sex="M");
+		offspring = subpop.addCrossed(individual, mate);
+	}
 }
 
 1 early() {
-   sim.addSubpop("p1", K);
-   p1.individuals.tagF = 0.0;
+	sim.addSubpop("p1", K);
 }
 
 early() {
-   p1.fitnessScaling = K / p1.individualCount;
+	p1.fitnessScaling = K / p1.individualCount;
 }
 
 1: late() {
-   // this should happen *after* mortality (so, in late())
-   GENTIME[community.tick - 1] = mean(p1.individuals.tagF);
+	// this should happen *after* mortality (so, in late())
+	GENTIME[community.tick - 1] = mean(p1.individuals.meanParentAge);
 }
 
 100 late() {
-   sim.treeSeqOutput(
-      "generation_time.trees",
-      metadata=Dictionary("generation_times", GENTIME)
-   );
-   catn("Done! Mean generation time " + mean(GENTIME[50:99]));
+	sim.treeSeqOutput(
+		"generation_time.trees",
+		metadata=Dictionary("generation_times", GENTIME)
+		);
+	catn("Done! Mean generation time " + mean(GENTIME[50:99]));
 }

--- a/docs/time_units.md
+++ b/docs/time_units.md
@@ -192,11 +192,9 @@ Here is a script that computes this.
 In the simulation, females' fecundity increases with their age,
 and so we expect "generation time" to be larger than the mean age of individuals
 alive at a given time.
-In the script, we (a) assign to each individual a tag
-that records the average age of their parents,
-then (b) every tick, take the average of these tags across all extant individuals
-and store it in a vector, and (c) when we write out the tree sequence,
-store this vector in top-level metadata.
+In the script, we store the average of the mean parent ages across all 
+extant individuals every tick using SLiM Individuals' `meanParentAge` property, 
+and store the vector in top-level metadata when we write out the tree sequence.
 
 ```{literalinclude} generation_time.slim
 ```
@@ -206,7 +204,7 @@ slim -s 23 generation_time.slim | tail -n 1
 ```
 
 Now we can look at our empirical calculation of generation time.
-Note that we have initialized the first generation individuals to have tag 0.0,
+Note that the first generation individuals have a mean parent age of 0.0,
 so we expect generation time to go up at first.
 
 ```{code-cell}


### PR DESCRIPTION
Edits to use the new `meanParentAge` property introduced in SLiM 4.0.1, with minor edits in body of text to explain the update.  