### PR TITLE
deal with varying root times in recapitate (closes #307)

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -5,15 +5,16 @@
 **Bugfixes**:
 
 - From 1.0.1 back to 0.700, there was a bug in `recapitate` when using the
-    `ancestral_Ne` parameter that introduced a bottleneck to size Ne=1 for each
-    SLiM subpopulation 1 or 2 generations when recapitating tree sequences
-    produced by SLiM *unless* either (a) it was a WF simulation, with calls to
-    addSubPop() in first() or early() and treeSeqOutput() in late(), or (b) it
-    was a nonWF simulation, will calls to addSubPop() in first() and
-    treeSeqOutput() in early() or late(). The fix correctly starts the msprime
-    population with effective size `ancestral_Ne`  at the time of the roots,
-    which might be at the value of `ts.metadata['SLiM']['tick']`, this value
-    minus 1, or this value minus 2. (:user:`petrelharp`, :pr:`308`)
+    `ancestral_Ne` parameter that introduced a bottleneck to diploid size Ne=1
+    for each SLiM subpopulation for 1 or 2 generations *unless* either (a) it
+    was a WF simulation, with calls to addSubPop() in first() or early() and
+    treeSeqOutput() in late(), or (b) it was a nonWF simulation, with calls to
+    addSubPop() in first() and treeSeqOutput() in early() or late(). The fix
+    correctly starts the msprime population with effective size `ancestral_Ne`
+    at the time of the roots, which might be at the value of
+    `ts.metadata['SLiM']['tick']`, this value minus 1, or this value minus 2.
+    Furthermore, `recapitate` now throws a warning if any roots of any trees
+    are not at the same time as the others. (:user:`petrelharp`, :pr:`308`)
 
 
 

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,6 +2,21 @@
 [UPCOMING.X.X] - XXXX-XX-XX
 ***************************
 
+**Bugfixes**:
+
+- From 1.0.1 back to 0.700, there was a bug in `recapitate` when using the
+    `ancestral_Ne` parameter that introduced a bottleneck to size Ne=1 for each
+    SLiM subpopulation 1 or 2 generations when recapitating tree sequences
+    produced by SLiM *unless* either (a) it was a WF simulation, with calls to
+    addSubPop() in first() or early() and treeSeqOutput() in late(), or (b) it
+    was a nonWF simulation, will calls to addSubPop() in first() and
+    treeSeqOutput() in early() or late(). The fix correctly starts the msprime
+    population with effective size `ancestral_Ne`  at the time of the roots,
+    which might be at the value of `ts.metadata['SLiM']['tick']`, this value
+    minus 1, or this value minus 2. (:user:`petrelharp`, :pr:`308`)
+
+
+
 ***************************
 [1.0.1] - 2022-09-23
 ***************************

--- a/pyslim/methods.py
+++ b/pyslim/methods.py
@@ -9,13 +9,6 @@ from .provenance import *
 from .util import *
 
 
-class RootTimesMismatchWarning(UserWarning):
-    """
-    Warning to raise when the roots on a tree sequence input to recapitation
-    do not all have the same time.
-    """
-
-
 def recapitate(ts,
                ancestral_Ne=None,
                **kwargs
@@ -71,15 +64,17 @@ def recapitate(ts,
         if len(root_times) > 1 or not np.allclose(root_times, recap_time):
             message = (
                 "Not all roots of the provided tree sequence are at the time expected "
-                "by recapitate(). This could happen if you've simplified before "
-                "recapitating, or if you added new individuals without parents in SLiM "
-                "during the course of the simulation (e.g., with sim.addSubPop()). "
-                "If you wish to suppress this warning, you can use, e.g., "
-                "warnings.simplefilter('ignore', pyslim.RootTimesMismatchWarning) "
-                f"Expected root time: {recap_time} "
-                f"Observed root times: {root_times} "
+                "by recapitate(). This could happen if you've simplified in "
+                "python before recapitating (fix: don't simplify first). "
+                "If could also happen in other situations, e.g., "
+                "you added new individuals without parents in SLiM "
+                "during the course of the simulation with sim.addSubPop(), "
+                "in which case you will probably need to recapitate with "
+                "msprime.sim_ancestry(initial_state=ts, ...). "
+                f"(Expected root time: {recap_time}; "
+                f"Observed root times: {root_times})"
             )
-            warnings.warn(message, RootTimesMismatchWarning)
+            raise ValueError(message)
         demography = msprime.Demography.from_tree_sequence(ts)
         # must set pop sizes to >0 even though we merge immediately
         for pop in demography.populations:

--- a/pyslim/methods.py
+++ b/pyslim/methods.py
@@ -62,8 +62,9 @@ def recapitate(ts,
         # might be one or even two less than the "tick" value. We have access
         # to the stage the tree sequence was written out, but not the time it
         # was *started*. So, we'll just check if we need to subtract one or two.
-        # It'd be nice to consistency check *all* the roots but that might take awhile.
-        root_times = list(set([ts.node(n).time for n in ts.first().roots]))
+        # Consistency checking this requires looping over all the trees, unfortunately,
+        # but it avoids some common errors.
+        root_times = list(set([ts.node(n).time for t in ts.trees() for n in t.roots]))
         for adj in (1, 2):
             if np.allclose(root_times, recap_time - adj):
                 recap_time -= adj

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -190,9 +190,12 @@ class PyslimTestCase:
         # assert t1.time_units == t2.time_units
         # assert t1 == t2
 
-    def do_recapitate(self, ts, *args, **kwargs):
+    def do_recapitate(self, ts, ignore_root_warning=False, *args, **kwargs):
+        ignore_warnings = [msprime.TimeUnitsMismatchWarning]
+        if ignore_root_warning:
+            ignore_warnings.append(pyslim.RootTimesMismatchWarning)
         with warnings.catch_warnings():
-            warnings.simplefilter('ignore', msprime.TimeUnitsMismatchWarning)
+            warnings.simplefilter('ignore', tuple(ignore_warnings))
             recap = pyslim.recapitate(ts, *args, **kwargs)
         return recap
 

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -190,12 +190,9 @@ class PyslimTestCase:
         # assert t1.time_units == t2.time_units
         # assert t1 == t2
 
-    def do_recapitate(self, ts, ignore_root_warning=False, *args, **kwargs):
-        ignore_warnings = [msprime.TimeUnitsMismatchWarning]
-        if ignore_root_warning:
-            ignore_warnings.append(pyslim.RootTimesMismatchWarning)
+    def do_recapitate(self, ts, *args, **kwargs):
         with warnings.catch_warnings():
-            warnings.simplefilter('ignore', tuple(ignore_warnings))
+            warnings.simplefilter('ignore', msprime.TimeUnitsMismatchWarning)
             recap = pyslim.recapitate(ts, *args, **kwargs)
         return recap
 

--- a/tests/test_tree_sequence.py
+++ b/tests/test_tree_sequence.py
@@ -142,6 +142,12 @@ class TestRecapitate(tests.PyslimTestCase):
                         random_seed=123,
             )
 
+    def test_root_mismatch_warning(self):
+        ts = msprime.sim_ancestry(4, sequence_length=10, random_seed=12)
+        ts = pyslim.annotate(ts, model_type="nonWF", tick=1)
+        with pytest.warns(pyslim.RootTimesMismatchWarning):
+            rts = self.do_recapitate(ts, ancestral_Ne=10)
+
     def test_unique_names(self):
         ts = msprime.sim_ancestry(4, sequence_length=10, random_seed=12)
         ts = pyslim.annotate(ts, model_type="nonWF", tick=1)
@@ -152,7 +158,7 @@ class TestRecapitate(tests.PyslimTestCase):
         md.update({"name": "ancestral_ancestral", "slim_id": 1})
         t.populations.add_row(metadata=md)
         ts = t.tree_sequence()
-        rts = self.do_recapitate(ts, ancestral_Ne=10)
+        rts = self.do_recapitate(ts, ancestral_Ne=10, ignore_root_warning=True)
         names = [pop.metadata['name'] for pop in rts.populations()]
         assert len(set(names)) == len(names)
         assert names[0] == "ancestral"


### PR DESCRIPTION
This feels a little hacky, but I think it might be the best thing it's possible to do, actually, besides requiring that people always initialize and write out (and Remember) in the same stage.