### PR TITLE
explain no adjustment needed for WF sims

### DIFF
--- a/docs/time_units.md
+++ b/docs/time_units.md
@@ -75,6 +75,10 @@ then you'd want the mutation rate in units of mutations per year.
 
 ## Coalescence, recombination, and migration rates in recapitation
 
+*Note: this section is relevant for nonWF SLiM simulations:
+in a single-species WF simulation, one tick = one generation,
+so no adjustment is needed.*
+
 If you recapitate with msprime, then the same issue occurs for coalescence rates.
 This is less obvious, because "coalescence rate" is not an argument to msprime;
 rather, the coalescence rate in a given population

--- a/docs/time_units.md
+++ b/docs/time_units.md
@@ -75,7 +75,7 @@ then you'd want the mutation rate in units of mutations per year.
 
 ## Coalescence, recombination, and migration rates in recapitation
 
-*Note: this section is relevant for nonWF SLiM simulations:
+*Note: this section is only relevant for nonWF SLiM simulations:
 in a single-species WF simulation, one tick = one generation,
 so no adjustment is needed.*
 


### PR DESCRIPTION
From the email list:

> I am unsure whether I need to adjust the mutation, recombination rate and Ne by the generation time when recapitating with pyslim and adding neutral mutations with msprime. I have read many times the section about time units mismatch in pyslim manual (https://tskit.dev/pyslim/docs/latest/time_units.html), but most of the examples are nonWF oriented.