### PR TITLE
typo fix metdadata

### DIFF
--- a/pyslim/methods.py
+++ b/pyslim/methods.py
@@ -721,7 +721,7 @@ def _annotate_nodes_individuals(tables, age):
             # so no big deal
             ind_flags[j] |= INDIVIDUAL_ALIVE
         else:
-            md = ind.metdadata
+            md = ind.metadata
         ind_metadata.append(md)
     tables.individuals.set_columns(
         flags=ind_flags,


### PR DESCRIPTION
Fixed a little typo in the code: changed "ind.metdata" to "ind.metadata" that was making the function crash when annotating the individuals table
