### PR TITLE
Suggestion for vignette: a spatial simulation

### DIFF
--- a/docs/vignette_space.md
+++ b/docs/vignette_space.md
@@ -357,8 +357,8 @@ geog_dist = np.repeat(0.0, len(pairs))
 locs = ts.individuals_location
 for k, (i, j) in enumerate(pairs):
   geog_dist[k] = np.sqrt(np.sum(
-                    (locs[ind_ids[i], :]
-                     - locs[ind_ids[j], :])**2
+                    (locs[ind_ids[i], :2]
+                     - locs[ind_ids[j], :2])**2
                  ))
 ```
 


### PR DESCRIPTION
Hey, thank you for a helpful vignette on spatial simulations! I saw that the third entry of the location list is included when calculating the geographic distance. May I suggest using only the first two entries, since the example is in a two dimensional space?