### PR TITLE
Update methods.py

### DIFF
--- a/pyslim/methods.py
+++ b/pyslim/methods.py
@@ -35,7 +35,7 @@ def recapitate(ts,
     argument: see :func:`msprime.sim_ancestry`.
     
     In general, all defaults are whatever the defaults of
-    {meth}`msprime.sim_ancestry` are; this includes recombination rate, so
+    :func:`msprime.sim_ancestry` are; this includes recombination rate, so
     that if neither ``recombination_rate`` or a ``recombination_map`` are
     provided, there will be *no* recombination.
 


### PR DESCRIPTION
Docstring for recapitate. The documentation for the current version recapitate() function includes {meth}`msprime.sim_ancestry`, which should be modified.
See here: https://tskit.dev/pyslim/docs/latest/python_api.html#pyslim.recapitate