### PR TITLE
do not simulate null ancestry; closes #357

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,6 +2,15 @@
 UPCOMING
 ***************************
 
+**Bugfixes**:
+
+- Recapitation on tree sequences with null genomes would attempt to simulate
+    the history of those null genomes; this would in all but exceptional cases
+    fail with an error ("not all roots are at the time expected"). Now,
+    `recapitate` removes the "sample" flag from all such null genomes in
+    sampled individuals. (:user: `petrelharp`, :pr:`358`)
+    
+
 
 ***************************
 [1.0.4] - 2023-08-01

--- a/pyslim/methods.py
+++ b/pyslim/methods.py
@@ -55,7 +55,8 @@ def recapitate(ts,
     '''
     is_current_version(ts, _warn=True)
     has_null = False
-    for n in ts.samples():
+    for nid in ts.samples():
+        n = ts.node(nid)
         if n.metadata['is_null']:
             has_null = True
             break

--- a/tests/test_tree_sequence.py
+++ b/tests/test_tree_sequence.py
@@ -637,7 +637,7 @@ class TestReferenceSequence(tests.PyslimTestCase):
         ts = recipe["ts"]
         for _ in range(100):
             node = random.randint(0, ts.num_nodes - 1)
-            pos = random.randint(0, ts.sequence_length - 1)
+            pos = random.randint(0, int(ts.sequence_length - 1))
             tree = ts.at(pos)
             parent = tree.parent(node)
             a = pyslim.mutation_at(ts, node, pos)
@@ -664,7 +664,7 @@ class TestReferenceSequence(tests.PyslimTestCase):
                 assert len(ts.reference_sequence.data) == ts.sequence_length
                 for _ in range(100):
                     node = random.randint(0, ts.num_nodes - 1)
-                    pos = random.randint(0, ts.sequence_length - 1)
+                    pos = random.randint(0, int(ts.sequence_length - 1))
                     tree = ts.at(pos)
                     parent = tree.parent(node)
                     a = pyslim.nucleotide_at(ts, node, pos)


### PR DESCRIPTION
The downside here is that the resulting tree sequence can't be loaded back into SLiM. We could go and put the 'sample' flags back after recapitation, but it just seems weird to have them there anyhow. All this will be changing with the new model.