### PR TITLE
set nucleotide_based flag in generate_nucleotides; closes #368

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -67,12 +67,16 @@ https://tskit.dev/pyslim/docs/latest/previous_versions.html
     fail with an error ("not all roots are at the time expected"). Now, null
     genomes are "vacant" (see above) and `recapitate` removes their
     sample flags before recapitating (and optionally puts them back)
-    as described above (:user: `petrelharp`, :pr:`367`)
+    as described above (:user:`petrelharp`, :pr:`367`)
     
 - Previously, recapitation would require the roots of all trees to be
     at the same time (roughly) as the 'tick' stored in the top-level metadata;
     however, this would not be the case if the first population was added
-    later than the first tick. (:user: `petrelharp`, :pr:`382`)
+    later than the first tick. (:user:`petrelharp`, :pr:`382`)
+
+- The `generated_nucleotides` method now sets the `nucleotide_based` entry
+    in top-level metadata to True.
+    (:user:`petrelharp`, :pr:`385`)
 
 
 ***************************

--- a/pyslim/methods.py
+++ b/pyslim/methods.py
@@ -497,7 +497,9 @@ def generate_nucleotides(ts, reference_sequence=None, keep=True, seed=None):
                     max_time = md["slim_time"]
             states[mut.id] = this_da
             tables.mutations.append(mut.replace(metadata=ml))
-
+    md = tables.metadata
+    md['SLiM']['nucleotide_based'] = True
+    tables.metadata = md
     return tables.tree_sequence()
 
 

--- a/tests/test_tree_sequence.py
+++ b/tests/test_tree_sequence.py
@@ -969,6 +969,7 @@ class TestConvertNucleotides(tests.PyslimTestCase):
         # if check_transitions is True, verify that derived states differ
         # from parental states - which we try to do but is not guaranteed,
         # for instance, if keep=True or in other weird situations.
+        assert ts.metadata['SLiM']['nucleotide_based']
         assert len(ts.reference_sequence.data) == ts.sequence_length
         muts = {}
         ts_muts = {


### PR DESCRIPTION
This was an oversight; see #368.